### PR TITLE
Refactor document for .adoc formatting and layout support

### DIFF
--- a/modules/ROOT/pages/ahb_uart_lite.adoc
+++ b/modules/ROOT/pages/ahb_uart_lite.adoc
@@ -22,7 +22,7 @@ AHB UARTコアは、システムに 7個実装されています。
 |===
 
 .AHB UART Lite Registerメモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset |Symbol        |Register                          |Initial
 |0x0000 |UARTL_RXFIFOR |Rx FIFO Register                  |0x00000000

--- a/modules/ROOT/pages/boot.adoc
+++ b/modules/ROOT/pages/boot.adoc
@@ -2,23 +2,16 @@
 
 === NOR Flash for Configuration Memory
 
-SC-OBC Module A1は、FPGAの Bitstreamデータと Flight Softwareを NOR Flash
-Memoryに格納しています。
+SC-OBC Module A1は、FPGAの Bitstreamデータと Flight Softwareを NOR Flash Memoryに格納しています。
 
-ひとつの NOR Flash Memoryには、Goldenと Updateの
-2つのデータセットを想定しています。
+ひとつの NOR Flash Memoryには、Goldenと Updateの 2つのデータセットを想定しています。
 
-Goldenは、実績のあるデータを書き込みます。この領域は
-宇宙機の打ち上げ前に書き込み、以後
-書き換えを行わない事を想定しています。
+Goldenは、実績のあるデータを書き込みます。この領域は宇宙機の打ち上げ前に書き込み、以後 書き換えを行わない事を想定しています。
 Updateは、軌道上での書き換えを想定しています。
 もしも、Updateデータに問題がある場合は、Goldenに書き込まれたデータによって、Updateデータを復旧します。
 
-このように ひとつの NOR Flash
-Memoryに、2つのデータを書き込む事で、データの信頼性を確保しています。
-また、Configuraionデータを格納するための Flash Memroyは
-2個搭載されており、NOR Flash Memory 2を NOR Flash Memory
-1のミラーとする事により、信頼性の高いシステムを構築します。
+このように ひとつの NOR Flash Memoryに、2つのデータを書き込む事で、データの信頼性を確保しています。
+また、Configuraionデータを格納するための Flash Memroyは 2個搭載されており、NOR Flash Memory 2を NOR Flash Memory 1のミラーとする事により、信頼性の高いシステムを構築します。
 
 以下に NOR Flash Memoryのデータパーティションを示します。
 
@@ -36,21 +29,15 @@ image::NOR_Flash_for_Configuration.svg[NOR_Flash_for_Configuration]
 
 === FPGA Boot Flow
 
-FPGAの Bootには AMD 7シリーズ FPGAでサポートされている Fallback Multi
-Bootを活用しています。
+FPGAの Bootには AMD 7シリーズ FPGAでサポートされている Fallback Multi Bootを活用しています。
 
 Multi Bootフローを以下に示します。
 
 .NOR Flash for Configuration Data Partition
 image::MultiBoot_Flow.svg[MultiBoot_Flow]
 
-TRCHによって FPGAに電源が投入されると、FPGAは NOR Flash Memoryのアドレス
-0から Goldenイメージを読み込みます。 Goldenデータの読み込み中に Multi
-Bootの処理を見つけると、Updateイメージが格納されているアドレスにジャンプし、Updateイメージの読み込みを行います。
+TRCHによって FPGAに電源が投入されると、FPGAは NOR Flash Memoryのアドレス0から Goldenイメージを読み込みます。
+Goldenデータの読み込み中に Multi Bootの処理を見つけると、Updateイメージが格納されているアドレスにジャンプし、Updateイメージの読み込みを行います。
 
-読み込まれた Updateイメージが正常なデータであった場合、FPGAは
-Configurationを完了し Updateイメージで動作します。 読み込まれた
-Updateイメージに CRCエラーなどの問題があった場合、FPGAは
-Fallbackプロセスにより Goldenイメージの読み込みを行い、FPGAは
-Goldenイメージで動作します。
-
+読み込まれた Updateイメージが正常なデータであった場合、FPGAは Configurationを完了し Updateイメージで動作します。 読み込まれた
+Updateイメージに CRCエラーなどの問題があった場合、FPGAは Fallbackプロセスにより Goldenイメージの読み込みを行い、FPGAは Goldenイメージで動作します。

--- a/modules/ROOT/pages/can_controller.adoc
+++ b/modules/ROOT/pages/can_controller.adoc
@@ -8,7 +8,7 @@ IPコアです。 1 Mbpsのビットレートをサポートしています。
 CAN Controllerは、Base Address 0x4040_0000に配置されています。
 
 .CAN Controller Register メモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset |Symbol     |Register                                 |Initial
 |0x0000 |CAN_ENR    |CAN Enable Register                      |0x00000000
@@ -49,36 +49,33 @@ CAN Controllerは、Base Address 0x4040_0000に配置されています。
 
 CAN Enable Registerは、CAN通信におけるEnable設定を行うレジスタです。
 
-CAN_ENが Disableの時、CAN Controllerは CANバスに Recessive (High
-level)を出力し、メッセージの送受信を行いません。 CAN_ENが
-Enableになると、CANバス上に連続する 11bitの Recessiveを
-1回検出した後にエラーアクティブ状態となり、メッセージの送受信が可能となります。
+CAN_ENが Disableの時、CAN Controllerは CANバスに Recessive (High level)を出力し、メッセージの送受信を行いません。
+CAN_ENが Enableになると、CANバス上に連続する 11bitの Recessiveを 1回検出した後にエラーアクティブ状態となり、メッセージの送受信が可能となります。
 
 .CAN Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |CAN_EN |CAN Enable |CAN通信のEnableを設定します。0: Disable 1:
-Enable |R/W
+|bit  |Symbol |Field      |Description                    |R/W
+|31:1 |-      |Reserved   |Reserved                       |-
+|0    |CAN_EN |CAN Enable |CAN通信のEnableを設定します。 +
+0: Disable +
+1: Enable                                                  |R/W
 |===
 
 ==== CAN Time Quantum Prescaler Register (Offset 0x0008)
 
-CAN Time Quantum Prescaler Registerは、Time Quantum
-Clock周期の設定を行うレジスタです。 このレジスタは、CAN Enable
-Registerの CAN_ENビットが "0"の時のみ書き込みが可能です。
+CAN Time Quantum Prescaler Registerは、Time Quantum Clock周期の設定を行うレジスタです。
+
+このレジスタは、CAN Enable Registerの CAN_ENビットが "0"の時のみ書き込みが可能です。
 
 .CAN Time Quantum Prescaler Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |CAN_TQPSET |Time Quantum Cycle |Time Quantum
-Clockの時間(Tq)を設定します。この設定は、CANクロックのサイクル数を設定します。CANクロックは
-システムクロックの周波数によらず、常に 24 MHzです。 |R/W
+|bit   |Symbol     |Field              |Description                               |R/W
+|31:16 |-          |Reserved           |Reserved                                  |-
+|15:0  |CAN_TQPSET |Time Quantum Cycle |Time Quantum Clockの時間(Tq)を設定します。 +
+この設定は、CANクロックのサイクル数を設定します。
+CANクロックは システムクロックの周波数によらず、常に 24 MHzです。               |R/W
 |===
 
 Time Quantum Clock(Tq)に設定する値は、次の式で計算できます。
@@ -90,32 +87,21 @@ Tq[s] = CANクロック\ period[s] \times \left(CAN\_TQPSET+1\right)
 
 ==== CAN Bit Timing Setting Register (Offset 0x000C)
 
-CAN Bit Timing Setting
-Registerは、サンプリングや同期制御に必要なビット時間の設定を行うレジスタです。
-このレジスタは、CAN Enable Registerの CAN_ENビットが
-"0"の時のみ書き込みが可能です。
+CAN Bit Timing Setting Registerは、サンプリングや同期制御に必要なビット時間の設定を行うレジスタです。
+
+このレジスタは、CAN Enable Registerの CAN_ENビットが "0"の時のみ書き込みが可能です。
 
 .CAN Bit Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:9 |- |Reserved |Reserved |-
-
-|8:7 |CAN_SJW |Synchronization Jump Width
-|同期ジャンプ幅の最大時間(Tsjw)を設定します。このフィールドには、Tqのサイクル数を設定します。
-|R/W
-
-|6:4 |CAN_TS2 |Time Segment 2 |Phase
-Segment2の時間(Tts2)を設定します。このフィールドには、Tqのサイクル数を設定します。
-|R/W
-
-|3:0 |CAN_TS1 |Time Segment 1 |Phase
-Segment1の時間(Tts1)を設定します。このフィールドには、Tqのサイクル数を設定します。
-|R/W
+|bit  |Symbol  |Field                      |Description                                                                                      |R/W
+|31:9 |-       |Reserved                   |Reserved                                                                                         |-
+|8:7  |CAN_SJW |Synchronization Jump Width |同期ジャンプ幅の最大時間(Tsjw)を設定します。このフィールドには、Tqのサイクル数を設定します。|R/W
+|6:4  |CAN_TS2 |Time Segment 2             |Phase Segment2の時間(Tts2)を設定します。このフィールドには、Tqのサイクル数を設定します。     |R/W
+|3:0 |CAN_TS1  |Time Segment 1             |Phase Segment1の時間(Tts1)を設定します。このフィールドには、Tqのサイクル数を設定します。     |R/W
 |===
 
-Phase Segment1(Tts1)、Phase
-Segment2(Tts2)、同期ジャンプ幅(Tsjw)に設定する値は、次の式で計算できます。
+Phase Segment1(Tts1)、Phase Segment2(Tts2)、同期ジャンプ幅(Tsjw)に設定する値は、次の式で計算できます。
 
 [stem]
 ++++
@@ -134,251 +120,123 @@ Tsjw[s] = Tq[s] \times \left(CAN\_SJW+1\right)
 
 ==== CAN Error Count Register (Offset: 0x0010)
 
-CAN Error Count
-Registerは、CAN通信におけるエラーの検出回数を表示するレジスタです。
+CAN Error Count Registerは、CAN通信におけるエラーの検出回数を表示するレジスタです。
+
 エラー検出時に、カウンターをエラー要因に応じ決められた数のインクリメントを行います。
 
-Transmit Error Counter 及び Receive Error
-Counterは、以下の条件でリセットされます。
-
+Transmit Error Counter 及び Receive Error Counterは、以下の条件でリセットされます。
 * CAN Enable Registerの CAN_ENビットに "0"が書き込まれた時
-* CAN Controllerが Bus OFF状態になってから 11Bitの Recessiveビットを
-128回検出した時
+* CAN Controllerが Bus OFF状態になってから 11Bitの Recessiveビットを 128回検出した時
 
 .CAN Error Count Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:8 |CAN_RXECNT |Receive Error Counter |受信エラーをカウントする
-8bitのカウンタです。 |RO
-
-|7:0 |CAN_TXECNT |Transmit Error Counter |送信エラーをカウントする
-8bitのカウンタです。 |RO
+|bit   |Symbol     |Field                  |Description                                      |R/W
+|31:16 |-          |Reserved               |Reserved                                         |-
+|15:8  |CAN_RXECNT |Receive Error Counter  |受信エラーをカウントする 8bitのカウンタです。 |RO
+|7:0  |CAN_TXECNT  |Transmit Error Counter |送信エラーをカウントする 8bitのカウンタです。 |RO
 |===
 
 ==== CAN Status Register (Offset: 0x0018)
 
-CAN Status Registerは、CAN
-Controllerのステータスを表示するレジスタです。
+CAN Status Registerは、CAN Controllerのステータスを表示するレジスタです。
 
 .CAN Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7 |CAN_RXFFL |RX FIFO Full |RX FIFOの Full状態を示すビットです。0: RX
-FIFOは Not Full状態 1: RX FIFOは Full状態 |RO
-
-|6 |CAN_TXFFL |TX FIFO Full |TX FIFOの Full状態を示すビットです。0: TX
-FIFOは Not Full状態 1: TX FIFOが Full状態 |RO
-
-|5 |CAN_TXHBFL |TX High Priority Buffer Full |TX High Priority Bufferの
-Full状態を示すビットです。0: TX High Priority Bufferは Not Full状態 1:
-TX High Priority BufferはFull状態 |RO
-
-|4 |CAN_TXFNEP |TX FIFO Not Empty |TX FIFOの
-Empty状態を示すビットです。0: TX FIFOは Empty状態 1: TX FIFOは Not
-Empty状態 |RO
-
-|3:2 |CAN_ESTS |Error Status |Errorステータスを示すビットです。0b00:
-CAN_EN Disable 0b01: Error Active状態 0b10: Error Passive状態 0b11: Bus
-OFF状態 |RO
-
-|1 |CAN_EWRN |Error Warning |Error
-Warningステータスを示すビットです。Transmit Error Counterまたは Receive
-Error Counterが 96以上の値を示すとき、Error Warning状態と認識します。0:
-非Error Warning状態 1: Error Warning状態 |RO
-
-|0 |CAN_BBUSY |Bus Busy |CANバスのステータスを示すビットです。0: Bus
-Idle状態 または CAN_ENが Disable状態 1: Bus Busy状態
-(CANバスの通信が行われている状態) |RO
+|bit |Symbol |Field |Description                |R/W
+|31:8 |-          |Reserved                     |Reserved |-
+|7    |CAN_RXFFL  |RX FIFO Full                 |RX FIFOの Full状態を示すビットです。 +
+0: RX FIFOは Not Full状態 +
+1: RX FIFOは Full状態 |RO
+|6    |CAN_TXFFL  |TX FIFO Full                 |TX FIFOの Full状態を示すビットです。 +
+0: TX FIFOは Not Full状態 +
+1: TX FIFOが Full状態 |RO
+|5    |CAN_TXHBFL |TX High Priority Buffer Full |TX High Priority Bufferの Full状態を示すビットです。 +
+0: TX High Priority Bufferは Not Full状態 +
+1: TX High Priority BufferはFull状態 |RO
+|4    |CAN_TXFNEP |TX FIFO Not Empty            |TX FIFOの Empty状態を示すビットです。 +
+0: TX FIFOは Empty状態 +
+1: TX FIFOは Not Empty状態 |RO
+|3:2 |CAN_ESTS    |Error Status                 |Errorステータスを示すビットです。 +
+0b00: CAN_EN Disable +
+0b01: Error Active状態 +
+0b10: Error Passive状態 +
+0b11: Bus OFF状態 |RO
+|1   |CAN_EWRN    |Error Warning                |Error Warningステータスを示すビットです。
+Transmit Error Counterまたは Receive Error Counterが 96以上の値を示すとき、Error Warning状態と認識します。 +
+0: 非Error Warning状態 +
+1: Error Warning状態 |RO
+|0  |CAN_BBUSY    |Bus Busy                     |CANバスのステータスを示すビットです。 +
+0: Bus Idle状態 または CAN_ENが Disable状態 +
+1: Bus Busy状態 (CANバスの通信が行われている状態) |RO
 |===
 
 ==== CAN Interrupt Status Register (Offset: 0x0020)
 
-CAN Interrupt Status Registerは、CAN
-Controllerの動作における割り込みステータスレジスタです。
-それぞれのビットは
-1をセットすると、該当の割り込みをクリアする事ができます。
+CAN Interrupt Status Registerは、CAN Controllerの動作における割り込みステータスレジスタです。
+
+それぞれのビットは 1をセットすると、該当の割り込みをクリアする事ができます。
 
 .CAN Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:14 |- |Reserved |Reserved |-
-
-|13 |CAN_BUSOFF |Bus Off |Bus
-Offが発生したことを示すビットです。送信エラーカウント値が
-255を超える状態を検出した場合に本ビットが "1"にセットされます。 |R/WC
-
-|12 |CAN_ACKER |ACK Error |ACK
-Errorが発生したことを示すビットです。データフレーム、リモートフレームの送信中に
-ACK Slotビットで Recessive ("1")を検出した場合に本ビットが
-"1"にセットされます。 |R/WC
-
-|11 |CAN_BITER |BIT Error |BIT
-Errorが発生したことを示すビットです。送信中の値と異なる受信値を検出した場合に本ビットが
-"1"にセットされます。 |R/WC
-
-|10 |CAN_STFER |Stuff Error |Stuff
-Errorが発生したことを示すビットです。受信中に CANバス上で同一の値を連続
-6回検出した場合に本ビットが "1"にセットされます。 |R/WC
-
-|9 |CAN_FMER |Form Error |Form
-Errorが発生したことを示すビットです。受信中フレームの固定フィールド内で異なる
-Formatを検出した場合に本ビットが "1"にセットされます。 |R/WC
-
-|8 |CAN_CRCER |CRC Error |CRC
-Errorが発生したことを示すビットです。受信したデータフレーム、リモートフレームの
-CRC値の期待不一致を検出した場合に本ビットが "1"にセットされます。 |R/WC
-
-|7 |CAN_RXFOVF |RX FIFO Overflow |RX FIFOの
-Overflowが発生したことを示すビットです。RX
-FIFO容量を超えるメッセージを受信した場合に本ビットが
-"1"にセットされます。 |R/WC
-
-|6 |CAN_RXFUDF |RX FIFO Underflow |RX FIFOの
-Underflowが発生したことを示すビットです。RX FIFOが Empty状態の時に、CAN
-RX Message Registerから読み出しを行った場合に本ビットが
-"1"にセットされます。 |R/WC
-
-|5 |CAN_RXFVAL |RX FIFO Data Valid |RX
-FIFOにデータが格納されていることを示すビットです。RX FIFOが Not
-Empty状態となった場合に本ビットが
-"1"にセットされます。本ビットはクリアしても RX FIFOが
-Empty状態になるまで、セットされます。RX
-FIFOに複数のメッセージが格納されている場合、CAN RX Message
-Registerを読み出した時に、このビットがセットされます。 |R/WC
-
-|4 |CAN_RCVDN |CAN Message Receive Done
-|新しいメッセージを受信した事を示すビットです。データフレームまたはリモートフレームを正常に受信し、RX
-FIFOへの受信メッセージの格納が完了した時、本ビットが
-"1"にセットされます。 |R/WC
-
-|3 |CAN_TXFOVF |TX FIFO Overflow |TX FIFOの
-Overflowが発生したことを示すビットです。TX FIFO容量を超えるメッセージを
-CAN TX Message Registerにメッセージを書き込んだ場合、本ビットが
-"1"にセットされます。 |R/WC
-
-|2 |CAN_TXHBOVF |TX High Priority Buffer Overflow |TX High Priority
-Bufferの Overflowが発生したことを示すビットです。TX High Priority
-Bufferにメッセージが格納されている状態で CAN TX High Priority Message
-Registerにメッセージを書き込んだ場合、本ビットが "1"にセットされます。
-|R/WC
-
-|1 |CAN_ARBLST |CAN Arbitration Lost |送信メッセージの Arbitration
-Lostが発生した事を示すビットです。データフレーム、リモートフレームの送信中に他ノードとの送信競合が発生し、調停制御により送信を停止した時、本ビットが
-"1"にセットされます。 |R/WC
-
-|0 |CAN_TRNSDN |CAN Message Transmit Done
-|メッセージを送信した事を示すビットです。データフレームまたはリモートフレームの送信が正常に完了した時、本ビットが
-"1"にセットされます。 |R/WC
+|bit   |Symbol      |Field                            |Description |R/W
+|31:14 |-           |Reserved                         |Reserved  |-
+|13    |CAN_BUSOFF  |Bus Off                          |Bus Offが発生したことを示すビットです。送信エラーカウント値が 255を超える状態を検出した場合に本ビットが "1"にセットされます。 |R/WC
+|12    |CAN_ACKER   |ACK Error                        |ACK Errorが発生したことを示すビットです。データフレーム、リモートフレームの送信中に ACK Slotビットで Recessive ("1")を検出した場合に本ビットが "1"にセットされます。 |R/WC
+|11    |CAN_BITER   |BIT Error                        |BIT Errorが発生したことを示すビットです。送信中の値と異なる受信値を検出した場合に本ビットが "1"にセットされます。 |R/WC
+|10    |CAN_STFER   |Stuff Error                      |Stuff Errorが発生したことを示すビットです。受信中に CANバス上で同一の値を連続 6回検出した場合に本ビットが "1"にセットされます。 |R/WC
+|9     |CAN_FMER    |Form Error                       |Form Errorが発生したことを示すビットです。受信中フレームの固定フィールド内で異なる Formatを検出した場合に本ビットが "1"にセットされます。 |R/WC
+|8     |CAN_CRCER   |CRC Error                        |CRC Errorが発生したことを示すビットです。受信したデータフレーム、リモートフレームの CRC値の期待不一致を検出した場合に本ビットが "1"にセットされます。 |R/WC
+|7     |CAN_RXFOVF  |RX FIFO Overflow                 |RX FIFOの Overflowが発生したことを示すビットです。RX FIFO容量を超えるメッセージを受信した場合に本ビットが "1"にセットされます。 |R/WC
+|6     |CAN_RXFUDF  |RX FIFO Underflow                |RX FIFOの Underflowが発生したことを示すビットです。RX FIFOが Empty状態の時に、CAN RX Message Registerから読み出しを行った場合に本ビットが "1"にセットされます。 |R/WC
+|5     |CAN_RXFVAL  |RX FIFO Data Valid               |RX FIFOにデータが格納されていることを示すビットです。RX FIFOが Not Empty状態となった場合に本ビットが "1"にセットされます。本ビットはクリアしても RX FIFOが Empty状態になるまで、セットされます。RX FIFOに複数のメッセージが格納されている場合、CAN RX Message Registerを読み出した時に、このビットがセットされます。 |R/WC
+|4     |CAN_RCVDN   |CAN Message Receive Done         |新しいメッセージを受信した事を示すビットです。データフレームまたはリモートフレームを正常に受信し、RX FIFOへの受信メッセージの格納が完了した時、本ビットが "1"にセットされます。 |R/WC
+|3     |CAN_TXFOVF  |TX FIFO Overflow                 |TX FIFOの Overflowが発生したことを示すビットです。TX FIFO容量を超えるメッセージを CAN TX Message Registerにメッセージを書き込んだ場合、本ビットが "1"にセットされます。 |R/WC
+|2     |CAN_TXHBOVF |TX High Priority Buffer Overflow |TX High Priority Bufferの Overflowが発生したことを示すビットです。TX High Priority Bufferにメッセージが格納されている状態で CAN TX High Priority Message Registerにメッセージを書き込んだ場合、本ビットが "1"にセットされます。|R/WC
+|1     |CAN_ARBLST  |CAN Arbitration Lost             |送信メッセージの Arbitration Lostが発生した事を示すビットです。データフレーム、リモートフレームの送信中に他ノードとの送信競合が発生し、調停制御により送信を停止した時、本ビットが "1"にセットされます。 |R/WC
+|0     |CAN_TRNSDN  |CAN Message Transmit Done        |メッセージを送信した事を示すビットです。データフレームまたはリモートフレームの送信が正常に完了した時、本ビットが "1"にセットされます。 |R/WC
 |===
 
 ==== CAN Interrupt Enable Register (Offset: 0x0024)
 
-CAN Interrupt Enable Registerは、CAN
-Controllerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
+CAN Interrupt Enable Registerは、CAN Controllerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
 
 .CAN Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:14 |- |Reserved |Reserved |-
-
-|13 |CAN_BUSOFFENB |Bus Off Enable |CAN
-Controllerの動作においてCAN_BUSOFFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|12 |CAN_ACKERENB |ACK Error Enable |CAN
-Controllerの動作においてCAN_ACKERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|11 |CAN_BITERENB |BIT Error Enable |CAN
-Controllerの動作においてCAN_BITERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|10 |CAN_STFERENB |Stuff Error Enable |CAN
-Controllerの動作においてCAN_STFERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|9 |CAN_FMERENB |Form Error Enable |CAN
-Controllerの動作においてCAN_FMERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|8 |CAN_CRCERENB |CRC Error Enable |CAN
-Controllerの動作においてCAN_CRCERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|7 |CAN_RXFOVFENB |RX FIFO Overflow Enable |CAN
-Controllerの動作においてCAN_RXFOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|6 |CAN_RXFUDFENB |RX FIFO Underflow Enable |CAN
-Controllerの動作においてCAN_RXFUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|5 |CAN_RXFVALENB |RX FIFO Data Valid Enable |CAN
-Controllerの動作においてCAN_RXFVALイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|4 |CAN_RCVDNENB |CAN Message Receive Done Enable |CAN
-Controllerの動作においてCAN_RCVDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|3 |CAN_TXFOVFENB |TX FIFO Overflow Enable |CAN
-Controllerの動作においてCAN_TXFOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|2 |CAN_TXHBOVFENB |TX High Priority Buffer Overflow Enable |CAN
-Controllerの動作においてCAN_TXHBOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|1 |CAN_ARBLSTENB |CAN Arbitration Lost Enable |CAN
-Controllerの動作においてCAN_ARBLSTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|0 |CAN_TRNSDNENB |CAN Message Transmit Done Enable |CAN
-Controllerの動作においてCAN_TRNSDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
+|bit   |Symbol         |Field                                   |Description |R/W
+|31:14 |-              |Reserved                                |Reserved |-
+|13    |CAN_BUSOFFENB  |Bus Off Enable                          |CAN Controllerの動作においてCAN_BUSOFFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|12    |CAN_ACKERENB   |ACK Error Enable                        |CAN Controllerの動作においてCAN_ACKERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|11    |CAN_BITERENB   |BIT Error Enable                        |CAN Controllerの動作においてCAN_BITERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|10    |CAN_STFERENB   |Stuff Error Enable                      |CAN Controllerの動作においてCAN_STFERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|9     |CAN_FMERENB    |Form Error Enable                       |CAN Controllerの動作においてCAN_FMERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|8     |CAN_CRCERENB   |CRC Error Enable                        |CAN Controllerの動作においてCAN_CRCERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|7     |CAN_RXFOVFENB  |RX FIFO Overflow Enable                 |CAN Controllerの動作においてCAN_RXFOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|6     |CAN_RXFUDFENB  |RX FIFO Underflow Enable                |CAN Controllerの動作においてCAN_RXFUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|5     |CAN_RXFVALENB  |RX FIFO Data Valid Enable               |CAN Controllerの動作においてCAN_RXFVALイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|4     |CAN_RCVDNENB   |CAN Message Receive Done Enable         |CAN Controllerの動作においてCAN_RCVDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|3     |CAN_TXFOVFENB  |TX FIFO Overflow Enable                 |CAN Controllerの動作においてCAN_TXFOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|2     |CAN_TXHBOVFENB |TX High Priority Buffer Overflow Enable |CAN Controllerの動作においてCAN_TXHBOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|1     |CAN_ARBLSTENB  |CAN Arbitration Lost Enable             |CAN Controllerの動作においてCAN_ARBLSTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|0     |CAN_TRNSDNENB  |CAN Message Transmit Done Enable        |CAN Controllerの動作においてCAN_TRNSDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
 |===
 
 ==== CAN TX Message Register 1 (Offset 0x0030)
 
-CAN TX Message Register 1は、送信する CANフレームのメッセージ識別子
-(IDR)を TX FIFOに書き込むためのレジスタです。
+CAN TX Message Register 1は、送信する CANフレームのメッセージ識別子 (IDR)を TX FIFOに書き込むためのレジスタです。
 
 .CAN TX Message Register 1 ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |CAN_TXID1 |TX Standard Message ID |ID[28:18]を TX
-FIFOに書き込むためのフィールドです。標準フレーム、拡張フレームの両方の送信時に使用されます。
-|WO
-
-|20 |CAN_TXSRTR |TX Standard Remote Transmission Request
-|RTR、SRRビットを TX
-FIFOに書き込むためのビットです。標準フレーム、拡張フレームの両方の送信時に使用されます。-
-RTR(標準フレーム): 0: データフレーム 1: リモートフレーム -
-SRR(拡張フレーム): 1に設定する必要があります。 |WO
-
-|19 |CAN_TXIDE |TX Identifier Extension |IDEビットを TX
-FIFOに書き込むためのビットです。標準フレーム、拡張フレームの両方の送信時に使用されます。0:
-標準フレーム 1: 拡張フレーム |WO
-
-|18:1 |CAN_TXID2 |TX Extended Message ID |ID[17:0]を TX
-FIFOに書き込むためのフィールドです。拡張フレーム送信時のみ使用されます。CAN_TXIDEビットを
-"0"に設定した場合、このフィールドに書き込んだデータは使用されません。
-|WO
-
-|0 |CAN_TXERTR |TX Extended Remote Transmission Request
-|拡張フレーム送信でのみ使用されるRTRビット値を設定します。0:
-データフレーム 1: リモートフレーム
-CAN_TXIDEビットを0に設定した場合は、このビットの書き込み値は使用されません。
-|WO
+|bit   |Symbol     |Field                                   |Description |R/W
+|31:21 |CAN_TXID1  |TX Standard Message ID                  |ID[28:18]を TX FIFOに書き込むためのフィールドです。標準フレーム、拡張フレームの両方の送信時に使用されます。 |WO
+|20    |CAN_TXSRTR |TX Standard Remote Transmission Request |RTR、SRRビットを TX FIFOに書き込むためのビットです。標準フレーム、拡張フレームの両方の送信時に使用されます。RTR(標準フレーム): 0: データフレーム 1: リモートフレーム -SRR(拡張フレーム): 1に設定する必要があります。 |WO
+|19    |CAN_TXIDE  |TX Identifier Extension                 |IDEビットを TX FIFOに書き込むためのビットです。標準フレーム、拡張フレームの両方の送信時に使用されます。0: 標準フレーム 1: 拡張フレーム |WO
+|18:1  |CAN_TXID2  |TX Extended Message ID                  |ID[17:0]を TX FIFOに書き込むためのフィールドです。拡張フレーム送信時のみ使用されます。CAN_TXIDEビットを "0"に設定した場合、このフィールドに書き込んだデータは使用されません。 |WO
+|0     |CAN_TXERTR |TX Extended Remote Transmission Request |拡張フレーム送信でのみ使用されるRTRビット値を設定します。0: データフレーム 1: リモートフレーム CAN_TXIDEビットを0に設定した場合は、このビットの書き込み値は使用されません。 |WO
 |===
 
 ==== CAN TX Message Register 2 (Offset 0x0034)
@@ -977,9 +835,7 @@ IDEビットを比較に使用するかを設定するためのビットです�
 
 |18:1 |CAN_ID2AFM3 |Extended Message ID Mask 3 |CAN Acceptance Filter
 3において、拡張フレームの
-ID[17:0]フィールドのうち比較に使用するビットを設定するためのフィールドです。
-|R/W
-
+ID[17:0]フィールドのうち比較に使用するビットを設定するためのフィールドです。|R/W
 |0 |CAN_ERTRAFM3 |Extended Remote Transmission Request Mask 3 |CAN
 Acceptance Filter 3において、拡張フレームの
 RTRビットを比較に使用するかを設定するためのビットです。 |R/W
@@ -1457,6 +1313,5 @@ FIFOに格納されていることを示します。 RX FIFOは最大
 
 新しいメッセージの受信を待つ場合は、RCVDNビットの割り込みによりメッセージを受信したことを知ることができます。
 
-CAN RX Message Register 1～4は、CAN Enable Registerの CAN_ENビットが_
-"0"の状態でも読み出す事が出来ます。
+CAN RX Message Register 1～4は、CAN Enable Registerの CAN_ENビットが_"0"の状態でも読み出す事が出来ます。
 但し、この時は新しいメッセージの受信は行われません。

--- a/modules/ROOT/pages/general_purpose_timer.adoc
+++ b/modules/ROOT/pages/general_purpose_timer.adoc
@@ -1,44 +1,28 @@
 == General Purpose Timer
 
-General Purpose Timerは、SC-OBC-A1 FPGAの運用時間の管理や、FPGA内の
-CPUや IPコアへのタイミング通知を行うためのタイマーモジュールです。
-General Purpose Timerは、Global Timer・Software Interrupt
-Timer・Hardware Interrupt
-Timerと呼ばれる、3つの32bitアップカウンターで構成されています。
+General Purpose Timerは、SC-OBC-A1 FPGAの運用時間の管理や、FPGA内の CPUや IPコアへのタイミング通知を行うためのタイマーモジュールです。
+General Purpose Timerは、Global Timer・Software Interrupt Timer・Hardware Interrupt Timerと呼ばれる、3つの32bitアップカウンターで構成されています。
 
 Global Timerは、FPGAのリセット解除から動作する Free Run Timerです。
-リセットの解除後からの時刻を数えるために使われます。 Global
-Timerの最小時間は 0.0625秒であり、最大 268435455.9375秒(約 8年
-186日)までカウントする事ができます。 Software Interrupt Timerと Hardware
-Interrupt Timerの最小時間は Prescalerにより設定する事ができます。
+リセットの解除後からの時刻を数えるために使われます。 Global Timerの最小時間は 0.0625秒であり、最大 268435455.9375秒(約 8年 186日)までカウントする事ができます。
+Software Interrupt Timerと Hardware Interrupt Timerの最小時間は Prescalerにより設定する事ができます。
 
-Global Timerと Software Interrupt
-Timerは、CPUに割り込みを発生させるタイマーとして使用します。 Global
-Timerは タイマーに対し 4つの比較チャネルを持っており、Software Timerは
-8つの比較チャネルを持っています。
+Global Timerと Software Interrupt Timerは、CPUに割り込みを発生させるタイマーとして使用します。
+Global Timerは タイマーに対し 4つの比較チャネルを持っており、Software Timerは 8つの比較チャネルを持っています。
 
-Hardware Interrupt Timerは、SC-OBC-A1
-FPGAの内部のIPコアに対しイベントを通知する、Hardware
-Schedulerとして使用します。 Hardware Interrupt Timerは タイマーに対し
-8つの比較チャネルを持っており、そのうち 7つを
-IPコアへのイベントトリガに使用する事ができます。
+Hardware Interrupt Timerは、SC-OBC-A1 FPGAの内部のIPコアに対しイベントを通知する、Hardware Schedulerとして使用します。 Hardware Interrupt Timerは タイマーに対し
+8つの比較チャネルを持っており、そのうち 7つを IPコアへのイベントトリガに使用する事ができます。
 
-Hardware Interrupt Timerの出力チャネルと、接続されている IP
-Coreの対応を以下に示します。
+Hardware Interrupt Timerの出力チャネルと、接続されている IP Coreの対応を以下に示します。
 
 .Hardware Interrupt Timerの割り込み出力
 [cols=",,",options="header",]
 |===
-|Output Compare Channel |IP Core |Function
-|1 |None |Hardware Schedulerの周期を決めるタイマーとして使用
-
-|2 |System Monitor (Hardware Health Monitor) |Current Voltage
-Monitorからのデータ読み出しアクセス要求
-
-|3 |System Monitor (Hardware Health Monitor) |Temperature
-Sensorからのデータ読み出しアクセス要求
-
-|4-8 |Reserved |-
+|Output Compare Channel |IP Core                                  |Function
+|1                      |None                                     |Hardware Schedulerの周期を決めるタイマーとして使用
+|2                      |System Monitor (Hardware Health Monitor) |Current Voltage Monitorからのデータ読み出しアクセス要求
+|3                      |System Monitor (Hardware Health Monitor) |Temperature Sensorからのデータ読み出しアクセス要求
+|4-8                    |Reserved                                 |-
 |===
 
 === レジスタ詳細
@@ -46,398 +30,243 @@ Sensorからのデータ読み出しアクセス要求
 General Purpose Timerは、Base Address 0x4F05_0000に配置されています。
 
 .General Purpose Timer メモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
-|Offset |Symbol |Register |Initial
-|0x0000 |GPTMR_GTR |Global Timer Register |0x00000000
-
-|0x0004 |GPTMR_TECR |Timer Enable Control Register |0x00000000
-
-|0x0008 |GPTMR_SITRR |Software Interrupt Timer Remaining Register
-|0x00000000
-
-|0x000C |GPTMR_HITRR |Hardware Interrupt Timer Remaining Register
-|0x00000000
-
-|0x0010 |GPTMR_GTSR |Global Timer Interrupt Status Register |0x00000000
-
-|0x0014 |GPTMR_GTER |Global Timer Interrupt Enable Register |0x00000000
-
-|0x0020 |GPTMR_GTOCR1 |Global Timer Output Compare Register 1
-|0x00000000
-
-|0x0024 |GPTMR_GTOCR2 |Global Timer Output Compare Register 2
-|0x00000000
-
-|0x0028 |GPTMR_GTOCR3 |Global Timer Output Compare Register 3
-|0x00000000
-
-|0x002C |GPTMR_GTOCR4 |Global Timer Output Compare Register 4
-|0x00000000
-
-|0x0100 |GPTMR_SITCR |Software Interrupt Timer Control Register
-|0x00000000
-
-|0x0104 |GPTMR_SITPR |Software Interrupt Timer Prescaler Register
-|0x00000000
-
-|0x0108 |GPTMR_SITSR |Software Interrupt Timer Status Register
-|0x00000000
-
-|0x010C |GPTMR_SITER |Software Interrupt Timer Enable Register
-|0x00000000
-
-|0x0110 |GPTMR_SITOCR1 |Software Interrupt Timer Output Compare
-Register 1 |0x00000000
-
-|0x0114 |GPTMR_SITOCR2 |Software Interrupt Timer Output Compare
-Register 2 |0x00000000
-
-|0x0118 |GPTMR_SITOCR3 |Software Interrupt Timer Output Compare
-Register 3 |0x00000000
-
-|0x011C |GPTMR_SITOCR4 |Software Interrupt Timer Output Compare
-Register 4 |0x00000000
-
-|0x0120 |GPTMR_SITOCR5 |Software Interrupt Timer Output Compare
-Register 5 |0x00000000
-
-|0x0124 |GPTMR_SITOCR6 |Software Interrupt Timer Output Compare
-Register 6 |0x00000000
-
-|0x0128 |GPTMR_SITOCR7 |Software Interrupt Timer Output Compare
-Register 7 |0x00000000
-
-|0x012C |GPTMR_SITOCR8 |Software Interrupt Timer Output Compare
-Register 8 |0x00000000
-
-|0x0200 |GPTMR_HITCR |Hardware Interrupt Timer Control Register
-|0x00000000
-
-|0x0204 |GPTMR_HITPR |Hardware Interrupt Timer Prescaler Register
-|0x00000000
-
-|0x0210 |GPTMR_HITOCR1 |Hardware Interrupt Timer Output Compare
-Register 1 |0x00000000
-
-|0x0214 |GPTMR_HITOCR2 |Hardware Interrupt Timer Output Compare
-Register 2 |0x00000000
-
-|0x0218 |GPTMR_HITOCR3 |Hardware Interrupt Timer Output Compare
-Register 3 |0x00000000
-
-|0x021C |GPTMR_HITOCR4 |Hardware Interrupt Timer Output Compare
-Register 4 |0x00000000
-
-|0x0220 |GPTMR_HITOCR5 |Hardware Interrupt Timer Output Compare
-Register 5 |0x00000000
-
-|0x0224 |GPTMR_HITOCR6 |Hardware Interrupt Timer Output Compare
-Register 6 |0x00000000
-
-|0x0228 |GPTMR_HITOCR7 |Hardware Interrupt Timer Output Compare
-Register 7 |0x00000000
-
-|0x022C |GPTMR_HITOCR8 |Hardware Interrupt Timer Output Compare
-Register 8 |0x00000000
-
-|0xF000 |GPTMR_VER |General Purpose Timer IP Version Register |-
+|Offset |Symbol        |Register                                           |Initial
+|0x0000 |GPTMR_GTR     |Global Timer Register                              |0x00000000
+|0x0004 |GPTMR_TECR    |Timer Enable Control Register                      |0x00000000
+|0x0008 |GPTMR_SITRR   |Software Interrupt Timer Remaining Register        |0x00000000
+|0x000C |GPTMR_HITRR   |Hardware Interrupt Timer Remaining Register        |0x00000000
+|0x0010 |GPTMR_GTSR    |Global Timer Interrupt Status Register             |0x00000000
+|0x0014 |GPTMR_GTER    |Global Timer Interrupt Enable Register             |0x00000000
+|0x0020 |GPTMR_GTOCR1  |Global Timer Output Compare Register 1             |0x00000000
+|0x0024 |GPTMR_GTOCR2  |Global Timer Output Compare Register 2             |0x00000000
+|0x0028 |GPTMR_GTOCR3  |Global Timer Output Compare Register 3             |0x00000000
+|0x002C |GPTMR_GTOCR4  |Global Timer Output Compare Register 4             |0x00000000
+|0x0100 |GPTMR_SITCR   |Software Interrupt Timer Control Register          |0x00000000
+|0x0104 |GPTMR_SITPR   |Software Interrupt Timer Prescaler Register        |0x00000000
+|0x0108 |GPTMR_SITSR   |Software Interrupt Timer Status Register           |0x00000000
+|0x010C |GPTMR_SITER   |Software Interrupt Timer Enable Register           |0x00000000
+|0x0110 |GPTMR_SITOCR1 |Software Interrupt Timer Output Compare Register 1 |0x00000000
+|0x0114 |GPTMR_SITOCR2 |Software Interrupt Timer Output Compare Register 2 |0x00000000
+|0x0118 |GPTMR_SITOCR3 |Software Interrupt Timer Output Compare Register 3 |0x00000000
+|0x011C |GPTMR_SITOCR4 |Software Interrupt Timer Output Compare Register 4 |0x00000000
+|0x0120 |GPTMR_SITOCR5 |Software Interrupt Timer Output Compare Register 5 |0x00000000
+|0x0124 |GPTMR_SITOCR6 |Software Interrupt Timer Output Compare Register 6 |0x00000000
+|0x0128 |GPTMR_SITOCR7 |Software Interrupt Timer Output Compare Register 7 |0x00000000
+|0x012C |GPTMR_SITOCR8 |Software Interrupt Timer Output Compare Register 8 |0x00000000
+|0x0200 |GPTMR_HITCR   |Hardware Interrupt Timer Control Register          |0x00000000
+|0x0204 |GPTMR_HITPR   |Hardware Interrupt Timer Prescaler Register        |0x00000000
+|0x0210 |GPTMR_HITOCR1 |Hardware Interrupt Timer Output Compare Register 1 |0x00000000
+|0x0214 |GPTMR_HITOCR2 |Hardware Interrupt Timer Output Compare Register 2 |0x00000000
+|0x0218 |GPTMR_HITOCR3 |Hardware Interrupt Timer Output Compare Register 3 |0x00000000
+|0x021C |GPTMR_HITOCR4 |Hardware Interrupt Timer Output Compare Register 4 |0x00000000
+|0x0220 |GPTMR_HITOCR5 |Hardware Interrupt Timer Output Compare Register 5 |0x00000000
+|0x0224 |GPTMR_HITOCR6 |Hardware Interrupt Timer Output Compare Register 6 |0x00000000
+|0x0228 |GPTMR_HITOCR7 |Hardware Interrupt Timer Output Compare Register 7 |0x00000000
+|0x022C |GPTMR_HITOCR8 |Hardware Interrupt Timer Output Compare Register 8 |0x00000000
+|0xF000 |GPTMR_VER     |General Purpose Timer IP Version Register          |-
 |===
 
 ==== Global Timer Register (Offset: 0x0000)
 
 Global Timer Registerは、Global Timerの現在の値を示すレジスタです。
 
-Global Timerは、SC-OBC-A1
-FPGAの起動後に発生するシステムリセットの解除からカウントを開始するカウンターです。
+Global Timerは、SC-OBC-A1 FPGAの起動後に発生するシステムリセットの解除からカウントを開始するカウンターです。
 このタイマーの値を読み出す事で起動後の時間を知る事ができます。
 
 Global Timerの動作クロックは、FPGAに入力する原発クロックです。
 そのため、システムがどんな状態であってもカウント動作を行います。
 
-Timerの最小時間は、0.0625秒であり、最大 268435455.9375秒(約
-8年186日)までカウントする事ができます。
+Timerの最小時間は、0.0625秒であり、最大 268435455.9375秒(約 8年186日)までカウントする事ができます。
 
 .Global Timer Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:4 |GPTMR_GTINT |Global Timer Integer Field |Global
-Timerの整数部分を示すフィールドです。Bit 4が
-2^0秒を示します^。そのため、このフィールドは 1秒に
-1回インクリメントされます。Bit 4: 2^0^(1)秒 Bit 5: 2^1^ (2)秒 Bit 6:
-2^2^ (4)秒 ・・・ Bit 31: 2^27^ (134217728)秒
-このフィールドは、システムの起動後
-ソフトウェアによって書き換える事ができます。 |R/W
+|bit  |Symbol       |Field                      |Description |R/W
+|31:4 |GPTMR_GTINT |Global Timer Integer Field |Global Timerの整数部分を示すフィールドです。Bit 4が 2^0秒を示します。そのため、このフィールドは 1秒に 1回インクリメントされます。 +
+Bit 4: 2^0 (1)秒 +
+Bit 5: 2^1 (2)秒 +
+Bit 6: 2^2 (4)秒 +
+・・・ +
+Bit 31: 2^27 (134217728)秒 +
+このフィールドは、システムの起動後、ソフトウェアによって書き換える事ができます。 |R/W
 
-|3:0 |GPTMR_GTFLOAT |Global Timer Float Field |Global
-Timerの小数部分を示すフィールドです。Bit 0が
-2^-4秒を示します^。そのため、このフィールドは 0.0625秒に
-1回インクリメントされます。 Bit 3: 2^-1^ (0.5)秒　Bit 2: 2^-2^ (0.25)秒
-Bit 1: 2^-3^ (0.125)秒 Bit 0: 2^-4^ (0.0625)秒
-このフィールドは、GPTMR_GTINTフィールドに書き込みがあった時
-"0"にクリアされます。 |RO
+|3:0 |GPTMR_GTFLOAT |Global Timer Float Field |Global Timerの小数部分を示すフィールドです。 +
+Bit 0が 2^-4秒を示します。そのため、このフィールドは 0.0625秒に 1回インクリメントされます。 +
+Bit 3: 2^-1 (0.5)秒 +
+Bit 2: 2^-2 (0.25)秒 +
+Bit 1: 2^-3 (0.125)秒 +
+Bit 0: 2^-4 (0.0625)秒 +
+このフィールドは、GPTMR_GTINTフィールドに書き込みがあった時 "0"にクリアされます。 |RO
 |===
 
 ==== Timer Enable Control Register (Offset: 0x0004)
 
-Timer Enable Control Registerは、Software Interrupt Timerと Hardware
-Interrupt Timerの動作を制御するレジスタです。
+Timer Enable Control Registerは、Software Interrupt Timerと Hardware Interrupt Timerの動作を制御するレジスタです。
 
 .Timer Enable Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:2 |- |Reserved |Reserved |-
-
-|1 |GPTMR_HITEN |Hardware Interrupt Timer Enable |Hardware Interrupt
-Timerの動作設定を行います。 0: Hardware Interrupt Timer 無効 (停止) 1:
-Hardware Interrupt Timer 有効 (動作) |R/W
-
-|0 |GPTMR_SITEN |Software Interrupt Timer Enable |Software Interrupt
-Timerの動作設定を行います。 0: Software Interrupt Timer 無効 (停止) 1:
-Software Interrupt Timer 有効 (動作) |R/W
+|bit  |Symbol      |Field                           |Description |R/W
+|31:2 |-           |Reserved                        |Reserved    |-
+|1    |GPTMR_HITEN |Hardware Interrupt Timer Enable |Hardware Interrupt Timerの動作設定を行います。 +
+0: Hardware Interrupt Timer 無効 (停止) +
+1: Hardware Interrupt Timer 有効 (動作) |R/W
+|0    |GPTMR_SITEN |Software Interrupt Timer Enable |Software Interrupt Timerの動作設定を行います。 +
+0: Software Interrupt Timer 無効 (停止) +
+1: Software Interrupt Timer 有効 (動作) |R/W
 |===
 
 ==== Software Interrupt Timer Remaining Register (Offset: 0x0008)
 
-Software Interrupt Timer Remaining Registerは Software Interrupt
-Timerの現在のカウント値を示すレジスタです。
-
-Software Interrupt Timerの最小時間は、Software Interrupt Timer Prescaler
-Registerの設定値により決まります。
+Software Interrupt Timer Remaining Registerは Software Interrupt Timerの現在のカウント値を示すレジスタです。
+Software Interrupt Timerの最小時間は、Software Interrupt Timer Prescaler Registerの設定値により決まります。
 
 .Software Interrupt Timer Remaining Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCNT |Software Interrupt Timer Count |Software Interrupt
-Timerの現在のカウント値を示します。 |RO
+|bit  |Symbol       |Field                          |Description                                            |R/W
+|31:0 |GPTMR_SITCNT |Software Interrupt Timer Count |Software Interrupt Timerの現在のカウント値を示します。 |RO
 |===
 
 ==== Hardware Interrupt Timer Remaining Register (Offset: 0x000C)
 
-Hardware Interrupt Timer Remaining Registerは Hardware Interrupt
-Timerの現在のカウント値を示すレジスタです。
+Hardware Interrupt Timer Remaining Registerは Hardware Interrupt Timerの現在のカウント値を示すレジスタです。
 
-Hardware Interrupt Timerの最小時間は、Hardware Interrupt Timer Prescaler
-Registerの設定値により決まります。
+Hardware Interrupt Timerの最小時間は、Hardware Interrupt Timer Prescaler Registerの設定値により決まります。
 
 .Hardware Interrupt Timer Remaining Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCNT |Hardware Interrupt Timer Count |Hardware Interrupt
-Timerの現在のカウント値を示します。 |RO
+|bit  |Symbol       |Field                          |Description                                            |R/W
+|31:0 |GPTMR_HITCNT |Hardware Interrupt Timer Count |Hardware Interrupt Timerの現在のカウント値を示します。 |RO
 |===
 
 ==== Global Timer Interrupt Status Register (Offset: 0x0010)
 
-Global Timer Interrupt Status Registerは、Global
-Timerの割り込みステータスを示すレジスタです。
+Global Timer Interrupt Status Registerは、Global Timerの割り込みステータスを示すレジスタです。
 
-Global
-Timerに起因する割り込みが発生した時、割り込み要因に対応するビットがセットされます。
+Global Timerに起因する割り込みが発生した時、割り込み要因に対応するビットがセットされます。
 それぞれのビットは "1"をセットすると、割り込みをクリアする事ができます。
 
 .Global Timer Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |GPTMR_GTROVSTS |Global Timer Rollover Flag |Global Timerの Roll
-Overが発生した事を示すビットです。Global Timerがカウンター動作によって
-0xFFFFFFFFから 0x0に戻ったとき "1"にセットされます。 |R/WC
-
-|15:4 |- |Reserved |Reserved |-
-
-|3 |GPTMR_GTOCF4STS |Global Timer Output Compare Channel 4 Flag |Global
-Timer出力比較チャネル
-4の比較イベントが発生した事を示すビットです。Global
-Timerのカウンター値と Global Timer Output Compare Register
-4の値が一致したとき "1"にセットされます。 |R/WC
-
-|2 |GPTMR_GTOCF3STS |Global Timer Output Compare Channel 3 Flag |Global
-Timer出力比較チャネル
-3の比較イベントが発生した事を示すビットです。Global
-Timerのカウンター値と Global Timer Output Compare Register
-3の値が一致したとき "1"にセットされます。 |R/WC
-
-|1 |GPTMR_GTOCF2STS |Global Timer Output Compare Channel 2 Flag |Global
-Timer出力比較チャネル
-2の比較イベントが発生した事を示すビットです。Global
-Timerのカウンター値と Global Timer Output Compare Register
-2の値が一致したとき "1"にセットされます。 |R/WC
-
-|0 |GPTMR_GTOCF1STS |Global Timer Output Compare Channel 1 Flag |Global
-Timer出力比較チャネル
-1の比較イベントが発生した事を示すビットです。Global
-Timerのカウンター値と Global Timer Output Compare Register
-1の値が一致したとき "1"にセットされます。 |R/WC
+|bit   |Symbol          |Field                                      |Description                                                                                                                                                                           |R/W
+|31:17 |-               |Reserved                                   |Reserved                                                                                                                                                                              |-
+|16    |GPTMR_GTROVSTS  |Global Timer Rollover Flag                 |Global Timerの Roll Overが発生した事を示すビットです。Global Timerがカウンター動作によって 0xFFFFFFFFから 0x0に戻ったとき "1"にセットされます。                                       |R/WC
+|15:4  |-               |Reserved                                   |Reserved                                                                                                                                                                              |-
+|3     |GPTMR_GTOCF4STS |Global Timer Output Compare Channel 4 Flag |Global Timer出力比較チャネル 4の比較イベントが発生した事を示すビットです。Global Timerのカウンター値と Global Timer Output Compare Register 4の値が一致したとき "1"にセットされます。 |R/WC
+|2     |GPTMR_GTOCF3STS |Global Timer Output Compare Channel 3 Flag |Global Timer出力比較チャネル 3の比較イベントが発生した事を示すビットです。Global Timerのカウンター値と Global Timer Output Compare Register 3の値が一致したとき "1"にセットされます。 |R/WC
+|1     |GPTMR_GTOCF2STS |Global Timer Output Compare Channel 2 Flag |Global Timer出力比較チャネル 2の比較イベントが発生した事を示すビットです。Global Timerのカウンター値と Global Timer Output Compare Register 2の値が一致したとき "1"にセットされます。 |R/WC
+|0     |GPTMR_GTOCF1STS |Global Timer Output Compare Channel 1 Flag |Global Timer出力比較チャネル 1の比較イベントが発生した事を示すビットです。Global Timerのカウンター値と Global Timer Output Compare Register 1の値が一致したとき "1"にセットされます。 |R/WC
 |===
 
 ==== Global Timer Interrupt Enable Register (Offset: 0x0014)
 
-Global Timer Interrupt Enable Registerは、Global
-Timerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
+Global Timer Interrupt Enable Registerは、Global Timerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
 
-このレジスタで "1"にセットされた割り込みイネーブルビットと、Global Timer
-Interrupt Status Registerの対応する割り込みステータスビットが
-"1"にセットされた時、Global Timer割り込みを出力します。
+このレジスタで "1"にセットされた割り込みイネーブルビットと、Global Timer Interrupt Status Registerの対応する割り込みステータスビットが "1"にセットされた時、Global Timer割り込みを出力します。
 
 .Global Timer Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |GPTMR_GTROVENB |Global Timer Rollover Flag Enable
-|GPTMR_GTROVSTSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|15:4 |- |Reserved |Reserved |-
-
-|3 |GPTMR_GTOCF4ENB |Global Timer Output Compare Channel 4 Flag Enable
-|GPTMR_GTOCF4STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|2 |GPTMR_GTOCF3ENB |Global Timer Output Compare Channel 3 Flag Enable
-|GPTMR_GTOCF3STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|1 |GPTMR_GTOCF2ENB |Global Timer Output Compare Channel 2 Flag Enable
-|GPTMR_GTOCF2STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|0 |GPTMR_GTOCF1ENB |Global Timer Output Compare Channel 1 Flag Enable
-|GPTMR_GTOCF1STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
+|bit   |Symbol          |Field                                             |Description                                                                         |R/W
+|31:17 |-               |Reserved                                          |Reserved                                                                            |-
+|16    |GPTMR_GTROVENB  |Global Timer Rollover Flag Enable                 |GPTMR_GTROVSTSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。  |R/W
+|15:4  |-               |Reserved                                          |Reserved                                                                            |-
+|3     |GPTMR_GTOCF4ENB |Global Timer Output Compare Channel 4 Flag Enable |GPTMR_GTOCF4STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|2     |GPTMR_GTOCF3ENB |Global Timer Output Compare Channel 3 Flag Enable |GPTMR_GTOCF3STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|1     |GPTMR_GTOCF2ENB |Global Timer Output Compare Channel 2 Flag Enable |GPTMR_GTOCF2STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|0     |GPTMR_GTOCF1ENB |Global Timer Output Compare Channel 1 Flag Enable |GPTMR_GTOCF1STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
 |===
 
 ==== Global Timer Output Compare Register 1-4 (Offset: 0x0020-0x002C)
 
-Global Timer Output Compare Register 1-4は、Global
-Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
+Global Timer Output Compare Register 1-4は、Global Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
 
-Global Timerは、出力比較を行うチャネルを 4つ持っています。 Global
-Timerのカウント値と、本レジスタの設定値が一致したときに、対応するチャネルの比較イベントを生成します。
-このレジスタの値が
-"0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
+Global Timerは、出力比較を行うチャネルを 4つ持っています。 Global Timerのカウント値と、本レジスタの設定値が一致したときに、対応するチャネルの比較イベントを生成します。
+このレジスタの値が "0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
 
-.Global Timer Output Compare Register 1 ビットフィールド (Offset:
-0x0020)
+.Global Timer Output Compare Register 1 ビットフィールド (Offset: 0x0020)
 [cols="1,3,3,12,1",options="header",]
 |===
 |bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_GTCOMP1 |Global Timer Output Compare Channel 1 Value
-|出力比較チャネル 1の比較イベントを生成する Global
-Timerのカウント値を設定します。 |R/W
+|31:0 |GPTMR_GTCOMP1 |Global Timer Output Compare Channel 1 Value |出力比較チャネル 1の比較イベントを生成する Global Timerのカウント値を設定します。 |R/W
 |===
 
-.Global Timer Output Compare Register 2 ビットフィールド (Offset:
-0x0024)
+.Global Timer Output Compare Register 2 ビットフィールド (Offset: 0x0024)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_GTCOMP2 |Global Timer Output Compare Channel 2 Value
-|出力比較チャネル 2の比較イベントを生成する Global
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol        |Field                                       |Description                                                                       |R/W
+|31:0 |GPTMR_GTCOMP2 |Global Timer Output Compare Channel 2 Value |出力比較チャネル 2の比較イベントを生成する Global Timerのカウント値を設定します。 |R/W
 |===
 
-.Global Timer Output Compare Register 3 ビットフィールド (Offset:
-0x0028)
+.Global Timer Output Compare Register 3 ビットフィールド (Offset: 0x0028)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_GTCOMP3 |Global Timer Output Compare Channel 3 Value
-|出力比較チャネル 3の比較イベントを生成する Global
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol        |Field                                       |Description                                                                       |R/W
+|31:0 |GPTMR_GTCOMP3 |Global Timer Output Compare Channel 3 Value |出力比較チャネル 3の比較イベントを生成する Global Timerのカウント値を設定します。 |R/W
 |===
 
-.Global Timer Output Compare Register 4 ビットフィールド (Offset:
-0x002C)
+.Global Timer Output Compare Register 4 ビットフィールド (Offset: 0x002C)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_GTCOMP4 |Global Timer Output Compare Channel 4 Value
-|出力比較チャネル 4の比較イベントを生成する Global
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol        |Field                                       |Description                                                                       |R/W
+|31:0 |GPTMR_GTCOMP4 |Global Timer Output Compare Channel 4 Value |出力比較チャネル 4の比較イベントを生成する Global Timerのカウント値を設定します。 |R/W
 |===
 
 ==== Software Interrupt Timer Control Register (Offset: 0x0100)
 
-Software Interrupt Timer Control Registerは、Software Interrupt
-Timerの制御方法を指定するレジスタです。
+Software Interrupt Timer Control Registerは、Software Interrupt Timerの制御方法を指定するレジスタです。
 
-このレジスタは、Timer Enable Control Registerの
-GPTMR_SITENビットをセットする前に設定する必要があります。
+このレジスタは、Timer Enable Control Registerの GPTMR_SITENビットをセットする前に設定する必要があります。
 
 .Software Interrupt Timer Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:5 |- |Reserved |Reserved |-
-
-|4 |GPTMR_SITSWR |Software Interrupt Timer Software Reset |Software
-Interrupt
-Timerのソフトウェアリセットを行うためのビットです。このビットに"1"を書き込むと、Software
-Interrupt Timerに関連する以下レジスタのリセットを行います。 - Software
-Interrupt Timer Remaining Register(GPTMR_SITRR) - Software Interrupt
-Timer Control Register(GPTMR_SITCR) - Software Interrupt Timer
-Prescaler Register(GPTMR_SITPR) - Software Interrupt Timer Status
-Register(GPTMR_SITSR) - Software Interrupt Timer Enable
-Register(GPTMR_SITER) - Software Interrupt Timer Output Compare
-Register 1-8(GPTMR_SITOCR1-8)
+|bit  |Symbol         |Field |Description |R/W
+|31:5 |-              |Reserved |Reserved |-
+|4    |GPTMR_SITSWR   |Software Interrupt Timer Software Reset |Software Interrupt Timerのソフトウェアリセットを行うためのビットです。このビットに"1"を書き込むと、Software Interrupt Timerに関連する以下レジスタのリセットを行います。 +
+- Software Interrupt Timer Remaining Register(GPTMR_SITRR) +
+- Software Interrupt Timer Control Register(GPTMR_SITCR) +
+- Software Interrupt Timer Prescaler Register(GPTMR_SITPR) +
+- Software Interrupt Timer Status Register(GPTMR_SITSR) +
+- Software Interrupt Timer Enable Register(GPTMR_SITER) +
+- Software Interrupt Timer Output Compare Register 1-8(GPTMR_SITOCR1-8) +
 リセットが完了すると、このビットは"0"に戻ります。 |R/W
 
-|3:2 |- |Reserved |Reserved |-
+|3:2  |-              |Reserved                                 |Reserved |-
+|1    |GPTMR_SITRUNMD |Software Interrupt Timer Run Mode Select |出力比較チャネル 1で比較イベントが発生した時の Software Interrupt Timerの動作モードを設定します。 +
+0: Restartモード +
+1: Free Runモード +
+Restartモードは、出力比較チャネル 1で比較イベントが発生した時、Software Interrupt Timerのカウント値を "0"にリセットするモードです。Software Interrupt Timerは 0に戻った後、カウント動作を再開します。 +
+Free Runモードは、出力比較チャネル 1で比較イベントが発生した時、Software Interrupt Timerのカウント値をクリアせずカウントを続けるモードです。Software Interrupt Timerが 0xFFFFFFFFになると、Roll Overしカウンターは 0に戻ります。 |R/W
 
-|1 |GPTMR_SITRUNMD |Software Interrupt Timer Run Mode Select
-|出力比較チャネル 1で比較イベントが発生した時の Software Interrupt
-Timerの動作モードを設定します。0: Restartモード 1: Free Runモード
-Restartモードは、出力比較チャネル 1で比較イベントが発生した時、Software
-Interrupt Timerのカウント値を "0"にリセットするモードです。Software
-Interrupt Timerは 0に戻った後、カウント動作を再開します。Free
-Runモードは、出力比較チャネル 1で比較イベントが発生した時、Software
-Interrupt
-Timerのカウント値をクリアせずカウントを続けるモードです。Software
-Interrupt Timerが 0xFFFFFFFFになると、Roll Overしカウンターは
-0に戻ります。 |R/W
-
-|0 |GPTMR_SITENBMD |Software Interrupt Timer Enable Mode Select |Timer
-Enable Control Registerの GPTMR_SITENビットがセットされた時の Software
-Interrupt Timerの値を設定します。0: 前回のカウント値からカウントを再開
+|0 |GPTMR_SITENBMD |Software Interrupt Timer Enable Mode Select |Timer Enable Control Registerの GPTMR_SITENビットがセットされた時の Software Interrupt Timerの値を設定します。 +
+0: 前回のカウント値からカウントを再開 +
 1: カウント値を 0にクリアしカウントを開始 |R/W
 |===
 
 ==== Software Interrupt Timer Prescaler Register (Offset: 0x0104)
 
-Software Interrupt Timer Prescaler Registerは、Software Interrupt
-TimerのPrescalerを設定するためのレジスタです。
+Software Interrupt Timer Prescaler Registerは、Software Interrupt TimerのPrescalerを設定するためのレジスタです。
 
 Software Interrupt Timerは、24 MHzのクロックで動作します。
-このレジスタには、Software Interrupt
-Timerをカウントアップするための、クロックサイクル数を設定します。
+このレジスタには、Software Interrupt Timerをカウントアップするための、クロックサイクル数を設定します。
 
-このレジスタは、Timer Enable Control Registerの
-GPTMR_SITENビットをセットする前に設定する必要があります。
+このレジスタは、Timer Enable Control Registerの GPTMR_SITENビットをセットする前に設定する必要があります。
 
 .Software Interrupt Timer Prescaler Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |GPTMR_SITPSC |Software Interrupt Timer Prescale |Software
-Interrupt
-Timerをカウントアップするための動作クロックに対するサイクル数を設定します。
-|R/W
+|bit   |Symbol       |Field                             |Description                                                                                    |R/W
+|31:16 |-            |Reserved                          |Reserved                                                                                       |-
+|15:0  |GPTMR_SITPSC |Software Interrupt Timer Prescale |Software Interrupt Timerをカウントアップするための動作クロックに対するサイクル数を設定します。 |R/W
 |===
 
-GPTMR_SITPSCに設定する値は、Software Interrupt
-Timerの動作クロック周波数 (24
-MHz)とカウンターのカウントアップ間隔から、以下の計算で算出することができます。
+GPTMR_SITPSCに設定する値は、Software Interrupt Timerの動作クロック周波数 (24 MHz)とカウンターのカウントアップ間隔から、以下の計算で算出することができます。
 
 [stem]
 ++++
@@ -446,227 +275,113 @@ GPTMR\_SITPSC = 24 \times 10^6 \times Software\ Interrupt\ Timer\ Countup\ Inter
 
 ==== Software Interrupt Timer Status Register (Offset: 0x0108)
 
-Software Interrupt Timer Status Registerは、Software Interrupt
-Timerの割り込みステータスを示すレジスタです。
+Software Interrupt Timer Status Registerは、Software Interrupt Timerの割り込みステータスを示すレジスタです。
 
-Software Interrupt
-Timerに起因する割り込みが発生した時、割り込み要因に対応するビットがセットされます。
+Software Interrupt Timerに起因する割り込みが発生した時、割り込み要因に対応するビットがセットされます。
 それぞれのビットは "1"をセットすると、割り込みをクリアする事ができます。
 
 .Software Interrupt Timer Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |GPTMR_SITROVSTS |Software Interrupt Timer Rollover Flag |Software
-Interrupt TimerのRoll Overが発生した事を示すビットです。Software
-Interrupt Timerがカウンター動作によって 0xFFFFFFFFから
-0x0に戻ったときに本ビットが"1"にセットされます。 |R/WC
-
-|15:8 |- |Reserved |Reserved |-
-
-|7 |GPTMR_SITOCF8STS |Software Interrupt Timer Output Compare Channel 8
-Flag |Software Interrupt
-Timer出力比較チャネル8の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 8の値が一致したときに "1"にセットされます。 |R/WC
-
-|6 |GPTMR_SITOCF7STS |Software Interrupt Timer Output Compare Channel 7
-Flag |Software Interrupt
-Timer出力比較チャネル7の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 7の値が一致したときに "1"にセットされます。 |R/WC
-
-|5 |GPTMR_SITOCF6STS |Software Interrupt Timer Output Compare Channel 6
-Flag |Software Interrupt
-Timer出力比較チャネル6の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 6の値が一致したときに "1"にセットされます。 |R/WC
-
-|4 |GPTMR_SITOCF5STS |Software Interrupt Timer Output Compare Channel 5
-Flag |Software Interrupt
-Timer出力比較チャネル5の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 5の値が一致したときに "1"にセットされます。 |R/WC
-
-|3 |GPTMR_SITOCF4STS |Software Interrupt Timer Output Compare Channel 4
-Flag |Software Interrupt
-Timer出力比較チャネル4の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 4の値が一致したときに "1"にセットされます。 |R/WC
-
-|2 |GPTMR_SITOCF3STS |Software Interrupt Timer Output Compare Channel 3
-Flag |Software Interrupt
-Timer出力比較チャネル3の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 3の値が一致したときに "1"にセットされます。 |R/WC
-
-|1 |GPTMR_SITOCF2STS |Software Interrupt Timer Output Compare Channel 2
-Flag |Software Interrupt
-Timer出力比較チャネル2の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 2の値が一致したときに "1"にセットされます。 |R/WC
-
-|0 |GPTMR_SITOCF1STS |Software Interrupt Timer Output Compare Channel 1
-Flag |Software Interrupt
-Timer出力比較チャネル1の比較イベントが発生した事を示すビットです。Software
-Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare
-Register 1の値が一致したときに "1"にセットされます。 |R/WC
+|bit   |Symbol           |Field                                                  |Description |R/W
+|31:17 |-                |Reserved                                               |Reserved |-
+|16    |GPTMR_SITROVSTS  |Software Interrupt Timer Rollover Flag                 |Software Interrupt TimerのRoll Overが発生した事を示すビットです。Software Interrupt Timerがカウンター動作によって 0xFFFFFFFFから 0x0に戻ったときに本ビットが"1"にセットされます。 |R/WC
+|15:8  |-                |Reserved                                               |Reserved |-
+|7     |GPTMR_SITOCF8STS |Software Interrupt Timer Output Compare Channel 8 Flag |Software Interrupt Timer出力比較チャネル8の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 8の値が一致したときに "1"にセットされます。 |R/WC
+|6     |GPTMR_SITOCF7STS |Software Interrupt Timer Output Compare Channel 7 Flag |Software Interrupt Timer出力比較チャネル7の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 7の値が一致したときに "1"にセットされます。 |R/WC
+|5     |GPTMR_SITOCF6STS |Software Interrupt Timer Output Compare Channel 6 Flag |Software Interrupt Timer出力比較チャネル6の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 6の値が一致したときに "1"にセットされます。 |R/WC
+|4     |GPTMR_SITOCF5STS |Software Interrupt Timer Output Compare Channel 5 Flag |Software Interrupt Timer出力比較チャネル5の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 5の値が一致したときに "1"にセットされます。 |R/WC
+|3     |GPTMR_SITOCF4STS |Software Interrupt Timer Output Compare Channel 4 Flag |Software Interrupt Timer出力比較チャネル4の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 4の値が一致したときに "1"にセットされます。 |R/WC
+|2     |GPTMR_SITOCF3STS |Software Interrupt Timer Output Compare Channel 3 Flag |Software Interrupt Timer出力比較チャネル3の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 3の値が一致したときに "1"にセットされます。 |R/WC
+|1     |GPTMR_SITOCF2STS |Software Interrupt Timer Output Compare Channel 2 Flag |Software Interrupt Timer出力比較チャネル2の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 2の値が一致したときに "1"にセットされます。 |R/WC
+|0     |GPTMR_SITOCF1STS |Software Interrupt Timer Output Compare Channel 1 Flag |Software Interrupt Timer出力比較チャネル1の比較イベントが発生した事を示すビットです。Software Interrupt Timerのカウンター値と Software Interrupt Timer Output Compare Register 1の値が一致したときに "1"にセットされます。 |R/WC
 |===
 
 ==== Software Interrupt Timer Enable Register (Offset: 0x010C)
 
-Software Interrupt Timer Enable Registerは、Software Interrupt
-Timerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
+Software Interrupt Timer Enable Registerは、Software Interrupt Timerの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
 
-このレジスタで "1"にセットされた割り込みイネーブルビットと、Software
-Interrupt Timer Status Registerの対応する割り込みステータスビットが
-"1"にセットされた時、Software Interrupt Timerの割り込みを出力します。
+このレジスタで "1"にセットされた割り込みイネーブルビットと、Software Interrupt Timer Status Registerの対応する割り込みステータスビットが "1"にセットされた時、Software Interrupt Timerの割り込みを出力します。
 
 .Software Interrupt Timer Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |GPTMR_SITROVENB |Software Interrupt Timer Rollover Flag Enable
-|GPTMR_SITROVSTSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|15:8 |- |Reserved |Reserved |-
-
-|7 |GPTMR_SITOCF8ENB |Software Interrupt Timer Output Compare Channel 8
-Flag Enable
-|GPTMR_SITOCF8STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|6 |GPTMR_SITOCF7ENB |Software Interrupt Timer Output Compare Channel 7
-Flag Enable
-|GPTMR_SITOCF7STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|5 |GPTMR_SITOCF6ENB |Software Interrupt Timer Output Compare Channel 6
-Flag Enable
-|GPTMR_SITOCF6STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|4 |GPTMR_SITOCF5ENB |Software Interrupt Timer Output Compare Channel 5
-Flag Enable
-|GPTMR_SITOCF5STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|3 |GPTMR_SITOCF4ENB |Software Interrupt Timer Output Compare Channel 4
-Flag Enable
-|GPTMR_SITOCF4STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|2 |GPTMR_SITOCF3ENB |Software Interrupt Timer Output Compare Channel 3
-Flag Enable
-|GPTMR_SITOCF3STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|1 |GPTMR_SITOCF2ENB |Software Interrupt Timer Output Compare Channel 2
-Flag Enable
-|GPTMR_SITOCF2STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
-
-|0 |GPTMR_SITOCF1ENB |Software Interrupt Timer Output Compare Channel 1
-Flag Enable
-|GPTMR_SITOCF1STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。
-|R/W
+|bit   |Symbol           |Field                                                         |Description                                                                          |R/W
+|31:17 |-                |Reserved                                                      |Reserved                                                                             |-
+|16    |GPTMR_SITROVENB  |Software Interrupt Timer Rollover Flag Enable                 |GPTMR_SITROVSTSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。  |R/W
+|15:8  |-                |Reserved                                                      |Reserved                                                                             |-
+|7     |GPTMR_SITOCF8ENB |Software Interrupt Timer Output Compare Channel 8 Flag Enable |GPTMR_SITOCF8STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|6     |GPTMR_SITOCF7ENB |Software Interrupt Timer Output Compare Channel 7 Flag Enable |GPTMR_SITOCF7STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|5     |GPTMR_SITOCF6ENB |Software Interrupt Timer Output Compare Channel 6 Flag Enable |GPTMR_SITOCF6STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|4     |GPTMR_SITOCF5ENB |Software Interrupt Timer Output Compare Channel 5 Flag Enable |GPTMR_SITOCF5STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|3     |GPTMR_SITOCF4ENB |Software Interrupt Timer Output Compare Channel 4 Flag Enable |GPTMR_SITOCF4STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|2     |GPTMR_SITOCF3ENB |Software Interrupt Timer Output Compare Channel 3 Flag Enable |GPTMR_SITOCF3STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|1     |GPTMR_SITOCF2ENB |Software Interrupt Timer Output Compare Channel 2 Flag Enable |GPTMR_SITOCF2STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
+|0     |GPTMR_SITOCF1ENB |Software Interrupt Timer Output Compare Channel 1 Flag Enable |GPTMR_SITOCF1STSイベントが発生した時に、割り込み信号を出力するかどうかを設定します。 |R/W
 |===
 
 ==== Software Interrupt Timer Output Compare Register 1-8 (Offset: 0x0110-0x012C)
 
-Software Interrupt Timer Output Compare Register 1-8は、Software
-Interrupt
-Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
+Software Interrupt Timer Output Compare Register 1-8は、Software Interrupt Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
 
 Software Interrupt Timerは、出力比較を行うチャネルは 8つ持っています。
-Software Interrupt
-Timerのカウント値と、本レジスタの設定値が一致したとき、対応するチャネルの比較イベントを生成します。
-レジスタの値が
-"0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
+Software Interrupt Timerのカウント値と、本レジスタの設定値が一致したとき、対応するチャネルの比較イベントを生成します。
+レジスタの値が "0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
 
-.Software Interrupt Timer Output Compare Register 1 ビットフィールド
-(Offset: 0x0110)
+.Software Interrupt Timer Output Compare Register 1 ビットフィールド (Offset: 0x0110)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP1 |Software Interrupt Timer Output Compare Channel
-1 Value |出力比較チャネル 1の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP1 |Software Interrupt Timer Output Compare Channel 1 Value |出力比較チャネル 1の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 2 ビットフィールド
-(Offset: 0x0114)
+.Software Interrupt Timer Output Compare Register 2 ビットフィールド (Offset: 0x0114)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP2 |Software Interrupt Timer Output Compare Channel
-2 Value |出力比較チャネル 2の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP2 |Software Interrupt Timer Output Compare Channel 2 Value |出力比較チャネル 2の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 3 ビットフィールド
-(Offset: 0x0118)
+.Software Interrupt Timer Output Compare Register 3 ビットフィールド (Offset: 0x0118)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP3 |Software Interrupt Timer Output Compare Channel
-3 Value |出力比較チャネル 3の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP3 |Software Interrupt Timer Output Compare Channel 3 Value |出力比較チャネル 3の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 4 ビットフィールド
-(Offset: 0x011C)
+.Software Interrupt Timer Output Compare Register 4 ビットフィールド (Offset: 0x011C)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP4 |Software Interrupt Timer Output Compare Channel
-4 Value |出力比較チャネル 4の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP4 |Software Interrupt Timer Output Compare Channel 4 Value |出力比較チャネル 4の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 5 ビットフィールド
-(Offset: 0x0120)
+.Software Interrupt Timer Output Compare Register 5 ビットフィールド (Offset: 0x0120)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP5 |Software Interrupt Timer Output Compare Channel
-5 Value |出力比較チャネル 5の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP5 |Software Interrupt Timer Output Compare Channel 5 Value |出力比較チャネル 5の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 6 ビットフィールド
-(Offset: 0x0124)
+.Software Interrupt Timer Output Compare Register 6 ビットフィールド (Offset: 0x0124)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP6 |Software Interrupt Timer Output Compare Channel
-6 Value |出力比較チャネル 6の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP6 |Software Interrupt Timer Output Compare Channel 6 Value |出力比較チャネル 6の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 7 ビットフィールド
-(Offset: 0x0128)
+.Software Interrupt Timer Output Compare Register 7 ビットフィールド (Offset: 0x0128)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP7 |Software Interrupt Timer Output Compare Channel
-7 Value |出力比較チャネル 7の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP7 |Software Interrupt Timer Output Compare Channel 7 Value |出力比較チャネル 7の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Software Interrupt Timer Output Compare Register 8 ビットフィールド
-(Offset: 0x012C)
+.Software Interrupt Timer Output Compare Register 8 ビットフィールド (Offset: 0x012C)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_SITCOMP8 |Software Interrupt Timer Output Compare Channel
-8 Value |出力比較チャネル 8の比較イベントを生成する Software Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_SITCOMP8 |Software Interrupt Timer Output Compare Channel 8 Value |出力比較チャネル 8の比較イベントを生成する Software Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
 ==== Hardware Interrupt Timer Control Register (Offset: 0x0200)
@@ -680,131 +395,93 @@ GPTMR_HITENビットをセットする前に設定する必要があります。
 .Hardware Interrupt Timer Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:30 |GPTMR_HITOPMD8 |Hardware Interrupt Timer Output Compare Channel
-8 Operation Mode Select |出力比較チャネル 8で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|bit   |Symbol         |Field                                                                   |Description |R/W
+|31:30 |GPTMR_HITOPMD8 |Hardware Interrupt Timer Output Compare Channel 8 Operation Mode Select |出力比較チャネル 8で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|29:28 |GPTMR_HITOPMD7 |Hardware Interrupt Timer Output Compare Channel
-7 Operation Mode Select |出力比較チャネル 7で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|29:28 |GPTMR_HITOPMD7 |Hardware Interrupt Timer Output Compare Channel 7 Operation Mode Select |出力比較チャネル 7で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|27:26 |GPTMR_HITOPMD6 |Hardware Interrupt Timer Output Compare Channel
-6 Operation Mode Select |出力比較チャネル 6で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|27:26 |GPTMR_HITOPMD6 |Hardware Interrupt Timer Output Compare Channel 6 Operation Mode Select |出力比較チャネル 6で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|25:24 |GPTMR_HITOPMD5 |Hardware Interrupt Timer Output Compare Channel
-5 Operation Mode Select |出力比較チャネル 5で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|25:24 |GPTMR_HITOPMD5 |Hardware Interrupt Timer Output Compare Channel 5 Operation Mode Select |出力比較チャネル 5で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手のIPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|23:22 |GPTMR_HITOPMD4 |Hardware Interrupt Timer Output Compare Channel
-4 Operation Mode Select |出力比較チャネル 4で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|23:22 |GPTMR_HITOPMD4 |Hardware Interrupt Timer Output Compare Channel 4 Operation Mode Select |出力比較チャネル 4で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|21:20 |GPTMR_HITOPMD3 |Hardware Interrupt Timer Output Compare Channel
-3 Operation Mode Select |出力比較チャネル 3で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|21:20 |GPTMR_HITOPMD3 |Hardware Interrupt Timer Output Compare Channel 3 Operation Mode Select |出力比較チャネル 3で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|19:18 |GPTMR_HITOPMD2 |Hardware Interrupt Timer Output Compare Channel
-2 Operation Mode Select |出力比較チャネル 2で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|19:18 |GPTMR_HITOPMD2 |Hardware Interrupt Timer Output Compare Channel 2 Operation Mode Select |出力比較チャネル 2で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|17:16 |GPTMR_HITOPMD1 |Hardware Interrupt Timer Output Compare Channel
-1 Operation Mode Select |出力比較チャネル 1で比較イベントが発生した時の
-Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の
-IPコア仕様に合わせ設定する必要があります。0b00: 割り込みを無効にします。
-0b01: トグル形式で割り込みを出力します。 0b10:
-パルス形式の割り込みを出力します。 0b11:
-ハンドシェイク形式の割り込みを出力します。 |R/W
+|17:16 |GPTMR_HITOPMD1 |Hardware Interrupt Timer Output Compare Channel 1 Operation Mode Select |出力比較チャネル 1で比較イベントが発生した時の Hardware Interrupt信号の動作モードを定義するフィールドです。接続相手の IPコア仕様に合わせ設定する必要があります。 +
+0b00: 割り込みを無効にします。 +
+0b01: トグル形式で割り込みを出力します。 +
+0b10: パルス形式の割り込みを出力します。 +
+0b11: ハンドシェイク形式の割り込みを出力します。 |R/W
 
-|15:5 |- |Reserved |Reserved |-
+|15:5  |-              |Reserved                                                                |Reserved |-
+|4     |GPTMR_HITSWR   |Hardware Interrupt Timer Hardware Reset                                 |Hardware Interrupt Timerのソフトウェアリセットを行うためのビットです。このビットに"1"を書き込むと、Hardware Interrupt Timerに関連する以下のレジスタのリセットを行います。 +
+- Hardware Interrupt Timer Remaining Register(GPTMR_HITRR) +
+- Hardware Interrupt Timer Control Register(GPTMR_HITCR) +
+- Hardware Interrupt Timer Prescaler Register(GPTMR_HITPR) +
+- Hardware Interrupt Timer Output Compare Register 1-8(GPTMR_HITOCR1-8) +
+リセットが完了すると、このビットは "0"に戻ります。 |R/W
 
-|4 |GPTMR_HITSWR |Hardware Interrupt Timer Hardware Reset |Hardware
-Interrupt
-Timerのソフトウェアリセットを行うためのビットです。このビットに
-"1"を書き込むと、Hardware Interrupt
-Timerに関連する以下のレジスタのリセットを行います。 - Hardware Interrupt
-Timer Remaining Register(GPTMR_HITRR) - Hardware Interrupt Timer
-Control Register(GPTMR_HITCR) - Hardware Interrupt Timer Prescaler
-Register(GPTMR_HITPR) - Hardware Interrupt Timer Output Compare
-Register 1-8(GPTMR_HITOCR1-8) リセットが完了すると、このビットは
-"0"に戻ります。 |R/W
+|3:2   |-              |Reserved                                 |Reserved |-
+|1     |GPTMR_HITRUNMD |Hardware Interrupt Timer Run Mode Select |出力比較チャネル 1で比較イベントが発生した時の Hardware Interrupt Timerの動作モードを設定します。 +
+0: Restartモード +
+1: Free Runモード +
+Restartモードは、出力比較チャネル 1で比較イベントが発生した時、Hardware Interrupt Timerのカウント値を "0"にリセットするモードです。Hardware Interrupt Timerは 0に戻った後、カウント動作を再開します。 +
+Free Runモードは、出力比較チャネル 1で比較イベントが発生した時、Hardware Interrupt Timerのカウント値をクリアせずカウントを続けるモードです。Hardware Interrupt Timerが 0xFFFFFFFFになると、Roll Overしカウンターは 0に戻ります。 |R/W
 
-|3:2 |- |Reserved |Reserved |-
-
-|1 |GPTMR_HITRUNMD |Hardware Interrupt Timer Run Mode Select
-|出力比較チャネル 1で比較イベントが発生した時の Hardware Interrupt
-Timerの動作モードを設定します。0: Restartモード 1: Free Runモード
-Restartモードは、出力比較チャネル 1で比較イベントが発生した時、Hardware
-Interrupt Timerのカウント値を "0"にリセットするモードです。Hardware
-Interrupt Timerは 0に戻った後、カウント動作を再開します。Free
-Runモードは、出力比較チャネル 1で比較イベントが発生した時、Hardware
-Interrupt
-Timerのカウント値をクリアせずカウントを続けるモードです。Hardware
-Interrupt Timerが 0xFFFFFFFFになると、Roll Overしカウンターは
-0に戻ります。 |R/W
-
-|0 |GPTMR_HITENBMD |Hardware Interrupt Timer Enable Mode Select |Timer
-Enable Control Registerの GPTMR_HITENビットがセットされた時の Hardware
-Interrupt Timerの値を設定します。 0: 前回のカウント値からカウントを再開
+|0     |GPTMR_HITENBMD |Hardware Interrupt Timer Enable Mode Select |Timer Enable Control Registerの GPTMR_HITENビットがセットされた時の Hardware Interrupt Timerの値を設定します。 +
+0: 前回のカウント値からカウントを再開 +
 1: 値を 0にクリアしカウントを開始 |R/W
 |===
 
 ==== Hardware Interrupt Timer Prescaler Register (Offset: 0x0204)
 
-Hardware Interrupt Timer Prescaler Registerは、Hardware Interrupt
-Timerの Prescalerを設定するためのレジスタです。
+Hardware Interrupt Timer Prescaler Registerは、Hardware Interrupt Timerの Prescalerを設定するためのレジスタです。
 
 Hardware Interrupt Timerは、24 MHzのクロックで動作します。
-このレジスタには、Hardware Interrupt
-Timerをカウントアップするための、クロックサイクル数を設定します。
+このレジスタには、Hardware Interrupt Timerをカウントアップするための、クロックサイクル数を設定します。
 
-このレジスタは、Timer Enable Control Registerの
-GPTMR_HITENビットをセットする前に設定する必要があります。
+このレジスタは、Timer Enable Control Registerの GPTMR_HITENビットをセットする前に設定する必要があります。
 
 .Hardware Interrupt Timer Prescaler Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |GPTMR_HITPSC |Hardware Interrupt Timer Prescale |Hardware
-Interrupt
-Timerがカウントアップするための動作クロックに対するサイクル数を設定します。
-|R/W
+|bit   |Symbol       |Field                             |Description                                                                                   |R/W
+|31:16 |-            |Reserved                          |Reserved                                                                                      |-
+|15:0  |GPTMR_HITPSC |Hardware Interrupt Timer Prescale |Hardware Interrupt Timerがカウントアップするための動作クロックに対するサイクル数を設定します。|R/W
 |===
 
-GPTMR_HITPSCに設定する値は、Hardware Interrupt
-Timerの動作クロック周波数 (24
-MHz)とカウンターのカウントアップ間隔から、以下の計算で算出することができます。
+GPTMR_HITPSCに設定する値は、Hardware Interrupt Timerの動作クロック周波数 (24 MHz)とカウンターのカウントアップ間隔から、以下の計算で算出することができます。
 
 [stem]
 ++++
@@ -813,111 +490,77 @@ GPTMR\_HITPSC = 24 \times 10^6 \times Hardware\ Interrupt\ Timer\ Countup\ Inter
 
 ==== Hardware Interrupt Timer Output Compare Register 1-8 (Offset: 0x0210-0x022C)
 
-Hardware Interrupt Timer Output Compare Register 1-8は、Hardware
-Interrupt
-Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
+Hardware Interrupt Timer Output Compare Register 1-8は、Hardware Interrupt Timerのタイマー出力値に対する比較イベントを生成するための設定レジスタです。
 
 Hardware Interrupt Timerは、出力比較を行うチャネルを 8つ持っています。
-Hardware Interrupt
-Timerのカウント値と、本レジスタの設定値が一致したとき、対応するチャネルの比較イベントを生成します。
-このレジスタの値が
-"0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
+Hardware Interrupt Timerのカウント値と、本レジスタの設定値が一致したとき、対応するチャネルの比較イベントを生成します。
+このレジスタの値が "0"に設定されている場合、そのチャネルの出力比較機能は無効になります。
 
-.Hardware Interrupt Timer Output Compare Register 1 ビットフィールド
-(Offset: 0x0210)
+.Hardware Interrupt Timer Output Compare Register 1 ビットフィールド (Offset: 0x0210)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP1 |Hardware Interrupt Timer Output Compare Channel
-1 Value |出力比較チャネル 1の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP1 |Hardware Interrupt Timer Output Compare Channel 1 Value |出力比較チャネル 1の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 2 ビットフィールド
-(Offset: 0x0214)
+.Hardware Interrupt Timer Output Compare Register 2 ビットフィールド (Offset: 0x0214)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP2 |Hardware Interrupt Timer Output Compare Channel
-2 Value |出力比較チャネル 2の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP2 |Hardware Interrupt Timer Output Compare Channel 2 Value |出力比較チャネル 2の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 3 ビットフィールド
-(Offset: 0x0218)
+.Hardware Interrupt Timer Output Compare Register 3 ビットフィールド (Offset: 0x0218)
 [cos=l",,,,",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP3 |Hardware Interrupt Timer Output Compare Channel
-3 Value |出力比較チャネル 3の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP3 |Hardware Interrupt Timer Output Compare Channel 3 Value |出力比較チャネル 3の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 4 ビットフィールド
-(Offset: 0x021C)
+.Hardware Interrupt Timer Output Compare Register 4 ビットフィールド (Offset: 0x021C)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP4 |Hardware Interrupt Timer Output Compare Channel
-4 Value |出力比較チャネル 4の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP4 |Hardware Interrupt Timer Output Compare Channel 4 Value |出力比較チャネル 4の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 5 ビットフィールド
-(Offset: 0x0220)
+.Hardware Interrupt Timer Output Compare Register 5 ビットフィールド (Offset: 0x0220)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP5 |Hardware Interrupt Timer Output Compare Channel
-5 Value |出力比較チャネル 5の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP5 |Hardware Interrupt Timer Output Compare Channel 5 Value |出力比較チャネル 5の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 6 ビットフィールド
-(Offset: 0x0224)
+.Hardware Interrupt Timer Output Compare Register 6 ビットフィールド (Offset: 0x0224)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP6 |Hardware Interrupt Timer Output Compare Channel
-6 Value |出力比較チャネル 6の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP6 |Hardware Interrupt Timer Output Compare Channel 6 Value |出力比較チャネル 6の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 7 ビットフィールド
-(Offset: 0x0228)
+.Hardware Interrupt Timer Output Compare Register 7 ビットフィールド (Offset: 0x0228)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP7 |Hardware Interrupt Timer Output Compare Channel
-7 Value |出力比較チャネル 7の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP7 |Hardware Interrupt Timer Output Compare Channel 7 Value |出力比較チャネル 7の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
-.Hardware Interrupt Timer Output Compare Register 8 ビットフィールド
-(Offset: 0x022C)
+.Hardware Interrupt Timer Output Compare Register 8 ビットフィールド (Offset: 0x022C)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |GPTMR_HITCOMP8 |Hardware Interrupt Timer Output Compare Channel
-8 Value |出力比較チャネル 8の比較イベントを生成する Hardware Interrupt
-Timerのカウント値を設定します。 |R/W
+|bit  |Symbol         |Field                                                   |Description                                                                                   |R/W
+|31:0 |GPTMR_HITCOMP8 |Hardware Interrupt Timer Output Compare Channel 8 Value |出力比較チャネル 8の比較イベントを生成する Hardware Interrupt Timerのカウント値を設定します。 |R/W
 |===
 
 ==== General Purpose Timer IP Version Register (Offset: 0xF000)
 
-General Purpose Timer IP Version Registerは、General Purpose Timerの
-IPコアバージョンを示すレジスタです。
+General Purpose Timer IP Version Registerは、General Purpose Timerの IPコアバージョンを示すレジスタです。
 
 .General Purpose Timer IP Version Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |GPTMR_MAJVER |General Purpose Timer IP Major Version |General
-Purpose TimerコアのMajor Versionを示します。 |RO
-
-|23:16 |GPTMR_MINVER |General Purpose Timer IP Minor Version |General
-Purpose TimerコアのMinor Versionを示します。 |RO
-
-|15:0 |GPTMR_PATVER |General Purpose Timer IP Patch Version |General
-Purpose TimerコアのPatch Versionを示します。 |RO
+|bit   |Symbol       |Field                                  |Description                                          |R/W
+|31:24 |GPTMR_MAJVER |General Purpose Timer IP Major Version |General Purpose TimerコアのMajor Versionを示します。 |RO
+|23:16 |GPTMR_MINVER |General Purpose Timer IP Minor Version |General Purpose TimerコアのMinor Versionを示します。 |RO
+|15:0  |GPTMR_PATVER |General Purpose Timer IP Patch Version |General Purpose TimerコアのPatch Versionを示します。 |RO
 |===

--- a/modules/ROOT/pages/hrmem.adoc
+++ b/modules/ROOT/pages/hrmem.adoc
@@ -1,31 +1,23 @@
 == HRMEM (High-reliability Memory)
 
-HRMEM (High-reliability Memory)は、SC-OBC Module A1に実装される
-SRAMにアクセスを行うメモリコントローラモジュールです。
+HRMEM (High-reliability Memory)は、SC-OBC Module A1に実装されるSRAMにアクセスを行うメモリコントローラモジュールです。
 
-HRMEMのメモリ空間は、Address 0x00000000をベースとする 4
-MByteの領域に配置されており、CPU SubSystemの CPU Local
-Busを通じアクセスされます。 また、Main AXI Bus
-Systemに接続されるAXIバスからアクセスが可能なミラーアドレスが、Base
-Address 0x60000000に配置されています。
+HRMEMのメモリ空間は、Address 0x00000000をベースとする 4 MByteの領域に配置されており、CPU SubSystemの CPU Local
+Busを通じアクセスされます。 また、Main AXI Bus Systemに接続されるAXIバスからアクセスが可能なミラーアドレスが、Base Address 0x60000000に配置されています。
 
-HRMEMは SC-OBC-A1
-FPGAのシステムにおいて、CPUが使用するメインメモリとして動作します。
-そのため、SC-OBC-A1 FPGAに実装する
-CPUが効率的に動作できるよう、SRAMへのアクセスを最適化する機能が実装されています。
+HRMEMは SC-OBC-A1 FPGAのシステムにおいて、CPUが使用するメインメモリとして動作します。
+そのため、SC-OBC-A1 FPGAに実装する CPUが効率的に動作できるよう、SRAMへのアクセスを最適化する機能が実装されています。
 
-HRMEMは SRAMからのデータ読み出し時に 1 bit
-ECCエラーの発生を検出すると、エラーを修復する機能を持っています。
+HRMEMは SRAMからのデータ読み出し時に 1 bit ECCエラーの発生を検出すると、エラーを修復する機能を持っています。
 また、メモリスクラビング機能を持ち、SRAMの全領域のデータに対し定期的なエラーチェックとエラーの修復を行います。
 
 === レジスタ詳細
 
-HRMEMはデータを格納する Address 0x00000000からの 4
-MByte空間とは別に、HRMEMを制御するために使用するレジスタが配置されています。
+HRMEMはデータを格納する Address 0x00000000からの 4 MByte空間とは別に、HRMEMを制御するために使用するレジスタが配置されています。
 HRMEMのレジスタは、Base Address 0x40500000に配置されています。
 
 .HRMEM Register アドレスマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset |Symbol              |Register                                    |Initial
 |0x0000 |HRMEM_ECCCOLENR     |ECC Error Collect Enable Register           |0x00000001
@@ -45,126 +37,85 @@ HRMEMのレジスタは、Base Address 0x40500000に配置されています。
 
 ==== ECC Error Collect Enable Register (Offset: 0x0000)
 
-ECC Error Collect Enable Registerは、1bit
-ECCエラー検出時にメモリの修復のため訂正データの書き戻す機能を設定するためのレジスタです。
+ECC Error Collect Enable Registerは、1bit ECCエラー検出時にメモリの修復のため訂正データの書き戻す機能を設定するためのレジスタです。
 このレジスタのEnableにすると、訂正データの書き戻し機能が有効になります。
 
 .ECC Error Collect Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |ECCCOLEN |ECC Error Collect Enable
-|メモリ修復機能のEnable設定を行います。0: メモリ修復機能 OFF 1:
-メモリ修復機能 ON |R/W
+|bit  |Symbol    |Field                   |Description |R/W
+|31:1 |-         |Reserved                |Reserved    |-
+|0    |ECCCOLEN  |ECC Error Collect Enable|メモリ修復機能のEnable設定を行います。 +
+0: メモリ修復機能 OFF +
+1: メモリ修復機能 ON                                    |R/W
 |===
 
 ==== Memory Scrubing Control Register (Offset: 0x0008)
 
-Memory Scrubing Control
-Registerは、メモリスクラビング機能の設定を行うためのレジスタです。
-このレジスタのMemory Scrubing
-EnableをONにすると、SRAMの全フィールドの定期的な読み出し行い書き込まれたデータのチェックを行います。
+Memory Scrubing Control Registerは、メモリスクラビング機能の設定を行うためのレジスタです。
+このレジスタのMemory Scrubing EnableをONにすると、SRAMの全フィールドの定期的な読み出し行い書き込まれたデータのチェックを行います。
 
 メモリスクラビング機能は、SRAMの全領域のデータに対し定期的なエラーチェックを行う機能です。
-メモリスクラビング機能により検出したデータのエラーを修復する場合には、メモリ修復機能
-(ECC Error Collect Enable Registerの
-ECCCOLENビット)も有効にする必要があります。
+メモリスクラビング機能により検出したデータのエラーを修復する場合には、メモリ修復機能 (ECC Error Collect Enable RegisterのECCCOLENビット)も有効にする必要があります。
 
-MEMSCRCYCはメモリスクラビングのための
-メモリ読み出しが発生する間隔を設定します。 MEMSCRCYCの初期値は
-1791に設定されています。 この値は、およそ
-1分でメモリの全領域を検査できる設計値になっています。
+MEMSCRCYCはメモリスクラビングのための メモリ読み出しが発生する間隔を設定します。
+MEMSCRCYCの初期値は 1791に設定されています。
+この値は、およそ 1分でメモリの全領域を検査できる設計値になっています。
 
 .Memory Scrubing Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |MEMSCRCYC |Memory Scrubing Cycle
-|メモリスクラビングによる読み出しアクセスの間隔を設定するビットです。設定はシステムクロックのサイクル数で設定します。0:
-設定禁止 1: 1 サイクル 2: 2 サイクル … 65535: 65535 サイクル
-初期状態では、1791 Cycle間隔に設定されています。 |R/W
-
-|15:9 |- |Reserved |Reserved |-
-
-|8 |COLFSRDSTPB |Memory Scrubing Arbitration Enable |エラー修復データ
-FIFOが Full状態での
-メモリスクラビング制御方法を設定するビットです。本ビットが
-0の時、エラー修復データ FIFOが
-Fullになるとメモリスクラビング機能を停止します。また、本ビットが
-1の時、エラー修復データ FIFOが
-Fullになってもメモリスクラビング機能が停止しません。新しく検出したエラーの修復データは破棄します。
-|R/W
-
-|7:1 |- |Reserved |Reserved |-
-
-|0 |MEMSCRBEN |Memory Scrubing Enable |メモリスクラビング機能の
-Enable設定を行います。0: メモリスクラビング機能 OFF 1:
-メモリスクラビング機能 ON |R/W
+|bit   |Symbol      |Field                 |Description |R/W
+|31:16 |MEMSCRCYC   |Memory Scrubing Cycle              |メモリスクラビングによる読み出しアクセスの間隔を設定するビットです。設定はシステムクロックのサイクル数で設定します。 +
+0: 設定禁止 +
+1: 1 サイクル +
+2: 2 サイクル +
+… +
+65535: 65535 サイクル +
+初期状態では、1791 Cycle間隔に設定されています。         |R/W
+|15:9  |-           |Reserved                           |Reserved    |-
+|8     |COLFSRDSTPB |Memory Scrubing Arbitration Enable |エラー修復データ FIFOが Full状態でのメモリスクラビング制御方法を設定するビットです。 +
+本ビットが0の時、エラー修復データ FIFOがFullになるとメモリスクラビング機能を停止します。 +
+また、本ビットが 1の時、エラー修復データ FIFOがFullになってもメモリスクラビング機能が停止しません。新しく検出したエラーの修復データは破棄します。|R/W
+|7:1   |-           |Reserved               |Reserved |-
+|0     |MEMSCRBEN   |Memory Scrubing Enable |メモリスクラビング機能のEnable設定を行います。0: メモリスクラビング機能 OFF 1:メモリスクラビング機能 ON |R/W
 |===
 
 ==== HRMEM Interrupt Status Register (Offset: 0x0010)
 
-HRMEM Interrupt Status
-Registerは、HRMEMの割り込みステータスレジスタです。
+HRMEM Interrupt Status Registerは、HRMEMの割り込みステータスレジスタです。
 それぞれのビットは"1"をセットすると、割り込みをクリアする事ができます。
 
 .HRMEM Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:18 |- |Reserved |Reserved |-
-
-|17 |ATRDE1ERR |Auto Read Access 1bit ECC Error
-|メモリスクラビング機能により SRAMの読み出しアクセスが行われた時に、1
-bit ECC
-Errorを検出すると本ビットが"1"にセットされます。E1ERRINTビットの割り込みクリアを行うことで、本ビットの状態もクリアされます。
-|RO
-
-|16 |BUSRDE1ERR |AHB/AXI Bus Read Access 1bit ECC Error |AHB/AXI
-Busからのリードアクセスが行われた時に、1 bit ECC
-Errorを検出すると本ビットが"1"にセットされます。E1ERRINTビットの割り込みクリアを行うことで、本ビットの状態もクリアされます。
-|RO
-
-|15:9 |- |Reserved |Reserved |-
-
-|8 |ECDISINT |ECC Correct Data Discard |1 bit
-ECCエラー検出時、エラー修復データを破棄すると本ビットが
-"1"にセットされます。 |R/WC
-
-|7:1 |- |Reserved |Reserved |-
-
-|0 |E1ERRINT |1bit ECC Error |1 bit ECC
-Errorを検出すると本ビットが"1"にセットされます。 |R/WC
+|bit   |Symbol     |Field                                  |Description |R/W
+|31:18 |-          |Reserved                               |Reserved    |-
+|17    |ATRDE1ERR  |Auto Read Access 1bit ECC Error        |メモリスクラビング機能により SRAMの読み出しアクセスが行われた時に、1 bit ECC Errorを検出すると本ビットが"1"にセットされます。E1ERRINTビットの割り込みクリアを行うことで、本ビットの状態もクリアされます。|RO
+|16    |BUSRDE1ERR |AHB/AXI Bus Read Access 1bit ECC Error |AHB/AXI Busからのリードアクセスが行われた時に、1 bit ECC Errorを検出すると本ビットが"1"にセットされます。E1ERRINTビットの割り込みクリアを行うことで、本ビットの状態もクリアされます。 |RO
+|15:9  |-          |Reserved                               |Reserved |-
+|8     |ECDISINT   |ECC Correct Data Discard               |1 bit ECCエラー検出時、エラー修復データを破棄すると本ビットが "1"にセットされます。 |R/WC
+|7:1   |-          |Reserved                               |Reserved |-
+|0     |E1ERRINT   |1bit ECC Error                         |1 bit ECC Errorを検出すると本ビットが"1"にセットされます。 |R/WC
 |===
 
 ==== HRMEM Interrupt Enable Register (Offset: 0x0014)
 
-HRMEM Interrupt Enable
-Registerは、HRMEMの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
+HRMEM Interrupt Enable Registerは、HRMEMの動作において発生した割り込みイベントを割り込み出力信号に通知するか設定するためのレジスタです。
 
 .HRMEM Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
 |bit |Symbol |Field |Description |R/W
 |31:9 |- |Reserved |Reserved |-
-
-|8 |ECDISINTENB |ECC Correct Data Discard Enable
-|ECDISINTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
+|8 |ECDISINTENB |ECC Correct Data Discard Enable |ECDISINTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
 |7:1 |- |Reserved |Reserved |R/W
-
-|0 |E1ERRINTENB |1bit ECC Error Enable
-|E1ERRINTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
+|0 |E1ERRINTENB |1bit ECC Error Enable |E1ERRINTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
 |===
 
 ==== 1Bit ECC Error Count Register (Offset: 0x0020)
 
-1Bit ECC Error Count Registerは、1Bit
-ECCエラー検出回数を示すレジスタです。 1 Bit
+1Bit ECC Error Count Registerは、1Bit ECCエラー検出回数を示すレジスタです。 1 Bit
 ECCエラーを検出するたびに該当するカウンターをインクリメントします。
 
 カウンターが上限である 0xFFFFに達すると停止します。
@@ -173,20 +124,14 @@ ECCエラーを検出するたびに該当するカウンターをインクリ�
 .1Bit ECC Error Count Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |ATRDE1ERRCNT |Auto Read Access 1bit ECC Error Counter
-|メモリスクラビング機能による 読み出しアクセスが行われた時に検出した 1
-bit ECCエラーの検出回数を読み出すためのフィールドです。 |RO
-
-|15:0 |BUSRDE1ERRCNT |AHB/AXI Bus Read Access 1bit ECC Error Counter
-|AHB/AXI Busよりリードアクセスが行われた時に検出した 1 bit
-ECCエラーの検出回数を読み出すためのフィールドです。 |RO
+|bit   |Symbol |Field |Description |R/W
+|31:16 |ATRDE1ERRCNT  |Auto Read Access 1bit ECC Error Counter        |メモリスクラビング機能による 読み出しアクセスが行われた時に検出した 1 bit ECCエラーの検出回数を読み出すためのフィールドです。 |RO
+|15:0  |BUSRDE1ERRCNT |AHB/AXI Bus Read Access 1bit ECC Error Counter |AHB/AXI Busよりリードアクセスが行われた時に検出した 1 bit ECCエラーの検出回数を読み出すためのフィールドです。                 |RO
 |===
 
 ==== ECC Correct Data Discard Count Register (Offset: 0x0028)
 
-ECC Correct Data Discard Count
-Registerは、エラー修復データの破棄回数を表示するカウンターレジスタです。
+ECC Correct Data Discard Count Registerは、エラー修復データの破棄回数を表示するカウンターレジスタです。
 エラー修復データを破棄するたびに、本カウンターをインクリメントします。
 
 カウンターが上限である 0xFFFFに達すると停止します。
@@ -195,11 +140,9 @@ Registerは、エラー修復データの破棄回数を表示するカウンタ
 .ECC Correct Data Discard Count Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |ECDISCNT |ECC Correct Data Discard Counter
-|エラー修復データを破棄した回数を読み出すためのフィールドです。 |RO
+|bit   |Symbol   |Field                            |Description                                                    |R/W
+|31:16 |-        |Reserved                         |Reserved                                                       |-
+|15:0  |ECDISCNT |ECC Correct Data Discard Counter |エラー修復データを破棄した回数を読み出すためのフィールドです。 |RO
 |===
 
 ==== Error Count Clear Register (Offset: 0x002C)
@@ -210,142 +153,104 @@ Data Discardカウンターをクリアするためのレジスタです。
 .Error Count Clear Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |ECNTCLR |Error Count Clear |1 Bit ECC Errorカウンター、ECC Correct
-Data Discardカウンターをクリアするためのビットです。本ビットを
-1にセットすると、1 Bit ECC Errorカウンター、ECC Correct Data
-Discardカウンターをクリアする事ができます。本ビットの
-0の書き込みは何も影響しません。 |WO
+|bit  |Symbol  |Field             |Description |R/W
+|31:1 |-       |Reserved          |Reserved    |-
+|0    |ECNTCLR |Error Count Clear |1 Bit ECC Errorカウンター、ECC Correct Data Discardカウンターをクリアするためのビットです。 +
+本ビットを 1にセットすると、1 Bit ECC Errorカウンター、ECC Correct Data Discardカウンターをクリアする事ができます。本ビットの 0の書き込みは何も影響しません。 |WO
 |===
 
 ==== ECC Error Address Monitor Register (Offset: 0x0030)
 
-ECC Error Address Monitor Registerは、ECC
-Errorを検出したアドレスを表示するためのレジスタです。
+ECC Error Address Monitor Registerは、ECC Errorを検出したアドレスを表示するためのレジスタです。
 
-最後にECC Errorを検出したSRAMのアドレスが表示されます。 AHB/AXI
-Busからのリードアクセスが バス幅の 32 bitに対し
-Unalignedだった場合でも、32 bit境界のアドレスが表示されます。 また、AXI
-Busからの読み出しにおいて、ECC Errorを検出した場合、ミラーアドレスである
-0x60xxxxxxではなく、メモリの実アドレスである
-0x00xxxxxxのアドレスで表示されます。
+最後にECC Errorを検出したSRAMのアドレスが表示されます。
+AHB/AXI Busからのリードアクセスが バス幅の 32 bitに対し Unalignedだった場合でも、32 bit境界のアドレスが表示されます。
+また、AXI Busからの読み出しにおいて、ECC Errorを検出した場合、ミラーアドレスである 0x60xxxxxxではなく、メモリの実アドレスである 0x00xxxxxxのアドレスで表示されます。
 
 .ECC Error Address Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:22 |- |Reserved |Reserved |-
-
-|21:0 |ECCERRADR |ECC Error Address |1Bit ECC
-Errorを検出したアドレスを示します。 |RO
+|bit   |Symbol    |Field             |Description                                  |R/W
+|31:22 |-         |Reserved          |Reserved                                     |-
+|21:0  |ECCERRADR |ECC Error Address |1Bit ECC Errorを検出したアドレスを示します。 |RO
 |===
 
 ==== Prefetch Mode Control Register (Offset: 0x0070)
 
-Prefetch Mode Control
-Registerは、Prefetch機能を設定するためのレジスタです。
+Prefetch Mode Control Registerは、Prefetch機能を設定するためのレジスタです。
 
-Prefetch機能が有効の場合は、PFMDCTLビットの設定により
-Prefetchの対象として設定されている要因のリードアクセスが発生すると
-SRAMから Prefetch Bufferにデータを先読みします。 Prefetch
-Bufferへのデータの先読みは、リードアクセスが発生したアドレスから 8
-word境界までのデータを格納します。 Prefetchされたアドレス範囲に
-Prefetchの対象として設定されているリードアクセスがあった場合
-SRAMへのデータアクセスは行わず Prefetch
-Bufferに格納されたデータを返す事でメモリアクセスのパフォーマンスを向上します。
+Prefetch機能が有効の場合は、PFMDCTLビットの設定により Prefetchの対象として設定されている要因のリードアクセスが発生すると SRAMから Prefetch Bufferにデータを先読みします。
+Prefetch Bufferへのデータの先読みは、リードアクセスが発生したアドレスから 8 word境界までのデータを格納します。
+Prefetchされたアドレス範囲に Prefetchの対象として設定されているリードアクセスがあった場合 SRAMへのデータアクセスは行わず Prefetch Bufferに格納されたデータを返す事でメモリアクセスのパフォーマンスを向上します。
 
 .Prefetch Mode Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:2 |- |Reserved |Reserved |-
-
-|1:0 |PFMDCTL |Prefetch Mode Control |Prefetch機能を設定します。 bit[0]:
-Instruction fetchにおける Prefetch機能の有効/無効設定. bit[1]:
-Dataアクセスにおける Prefetch機能の有効/無効設定. 1: 設定有効. 0:
-設定無効 |R/W
+|bit  |Symbol  |Field                 |Description              |R/W
+|31:2 |-       |Reserved              |Reserved                 |-
+|1:0  |PFMDCTL |Prefetch Mode Control |Prefetch機能を設定します。 +
+bit[0]: Instruction fetchにおける Prefetch機能の有効/無効設定 +
+bit[1]: Dataアクセスにおける Prefetch機能の有効/無効設定 +
+1: 設定有効 +
+0: 設定無効                                                      |R/W
 |===
 
 ==== Special Prefetch Enable Register (Offset: 0x0074)
 
-Special Prefetch Enable Registerは、特定のアドレスに対する
-Prefetch機能を設定するためのレジスタです。
+Special Prefetch Enable Registerは、特定のアドレスに対するPrefetch機能を設定するためのレジスタです。
 
-Special Prefetch Enableビットの設定により、特定のアドレスの
-Prefetch機能が有効になっている場合、Prefetchの対象として設定されている要因のリードアクセスにより読み出されるアドレスが、Special
-Prefetch Address Setting Registerに設定されている
-ベースアドレスと一致した場合、そのアクセスを Prefetch対象と判定します。
-Prefetch対象のアクセスが発生した場合、アクセスの発生したアドレスから 8
-word境界までのデータを SRAMから Prefetch Bufferに先読みします。
-Prefetchされたアドレス範囲にリードアクセスがあった場合
-SRAMへのデータアクセスは行わず Prefetch
-Bufferに格納されたデータを返す事でメモリアクセスのパフォーマンスを向上します。
+Special Prefetch Enableビットの設定により、特定のアドレスの Prefetch機能が有効になっている場合、Prefetchの対象として設定されている要因のリードアクセスにより読み出されるアドレスが、Special Prefetch Address Setting Registerに設定されているベースアドレスと一致した場合、そのアクセスを Prefetch対象と判定します。
+Prefetch対象のアクセスが発生した場合、アクセスの発生したアドレスから 8 word境界までのデータを SRAMから Prefetch Bufferに先読みします。
+Prefetchされたアドレス範囲にリードアクセスがあった場合 SRAMへのデータアクセスは行わず Prefetch Bufferに格納されたデータを返す事でメモリアクセスのパフォーマンスを向上します。
 
-Special Pregetch Bufferに格納されたデータは、他のアドレスの
-リードアクセスにより更新される事は無く、指定されたアドレスの
-Prefetchデータを保持し続ける事ができます。 特定アドレスに対する
-Prefetch機能は 2つのベースアドレスを設定する事ができます。
+Special Pregetch Bufferに格納されたデータは、他のアドレスのリードアクセスにより更新される事は無く、指定されたアドレスの Prefetchデータを保持し続ける事ができます。
+特定アドレスに対する Prefetch機能は 2つのベースアドレスを設定する事ができます。
 
 CPUから頻繁に読み出されるアドレスがある場合、この機能を使用するとパフォーマンスを向上させる事ができます。
-Prefetch Bufferに格納されているデータに書き込みを行うと、Prefetch
-Bufferのデータはフラッシュされてしまうため、書き込みが多く発生するアドレスに
-この機能を使用しても効果は少なくなってしまいます。
+Prefetch Bufferに格納されているデータに書き込みを行うと、Prefetch Bufferのデータはフラッシュされてしまうため、書き込みが多く発生するアドレスにこの機能を使用しても効果は少なくなってしまいます。
 
-尚、Prefetch Mode Control Registerの PFMDCTLフィールドが
-2'b00に設定されている場合、本レジスタの設定は無効となります。
+尚、Prefetch Mode Control Registerの PFMDCTLフィールドが 2'b00に設定されている場合、本レジスタの設定は無効となります。
 
 .Special Prefetch Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:2 |- |Reserved |Reserved |-
-
-|1:0 |SPPFENB |Special Prefetch Enable
-|専用アドレスのPrefetch機能を設定します。 2b00: Special Prefetch未使用
-2b01: Special Prefetch1のみ使用 2b10: Special Prefetch2のみ使用 2b11:
-Special Prefetch1/2双方使用 |R/W
+|bit  |Symbol  |Field                   |Description                             |R/W
+|31:2 |-       |Reserved                |Reserved                                |-
+|1:0  |SPPFENB |Special Prefetch Enable |専用アドレスのPrefetch機能を設定します。 +
+2b00: Special Prefetch未使用 +
+2b01: Special Prefetch1のみ使用 +
+2b10: Special Prefetch2のみ使用 +
+2b11: Special Prefetch1/2双方使用                                                 |R/W
 |===
 
 ==== Special Prefetch Address Setting Register 1 (Offset: 0x0080)
 
-Special Prefetch Address Setting Register 1は、Special Prefetch Buffer
-1に Prefetchするアドレスを設定するためのレジスタです。
+Special Prefetch Address Setting Register 1は、Special Prefetch Buffer 1に Prefetchするアドレスを設定するためのレジスタです。
 
-Special Prefetch Enable Registerの SPPFENB[0]ビットが
-1に設定されている場合、本レジスタの設定が有効となります。
+Special Prefetch Enable Registerの SPPFENB[0]ビットが 1に設定されている場合、本レジスタの設定が有効となります。
 
 .Special Prefetch Address Setting Register 1 ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:22 |- |Reserved |Reserved |-
-
-|21:5 |SPPFADR1 |Special Prefetch Address 1 |Special Prefetch Buffer 1に
-Prefetchするデータのベースアドレスを設定します。 |R/W
-
-|4:0 |- |Reserved |Reserved |-
+|bit   |Symbol   |Field                      |Description                                                                  |R/W
+|31:22 |-        |Reserved                   |Reserved                                                                     |-
+|21:5  |SPPFADR1 |Special Prefetch Address 1 |Special Prefetch Buffer 1に Prefetchするデータのベースアドレスを設定します。 |R/W
+|4:0   |-        |Reserved                   |Reserved                                                                     |-
 |===
 
 ==== Special Prefetch Address Setting Register 2 (Offset: 0x0084)
 
-Special Prefetch Address Setting Register 2は、Special Prefetch Buffer
-2に Prefetchするアドレスを設定するためのレジスタです。
+Special Prefetch Address Setting Register 2は、Special Prefetch Buffer 2に Prefetchするアドレスを設定するためのレジスタです。
 
-Special Prefetch Enable Registerの SPPFENB[1]ビットが
-1に設定されている場合、本レジスタの設定が有効となります。
+Special Prefetch Enable Registerの SPPFENB[1]ビットが 1に設定されている場合、本レジスタの設定が有効となります。
 
 .Special Prefetch Address Setting Register 2 ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:22 |- |Reserved |Reserved |-
-
-|21:5 |SPPFADR2 |Special Prefetch Address 2 |Special Prefetch
-Buffer2にPrefetchするデータのベースアドレスを設定します。 |R/W
-
-|4:0 |- |Reserved |Reserved |-
+|bit   |Symbol   |Field                      |Description                                                                |R/W
+|31:22 |-        |Reserved                   |Reserved                                                                   |-
+|21:5  |SPPFADR2 |Special Prefetch Address 2 |Special Prefetch Buffer2にPrefetchするデータのベースアドレスを設定します。 |R/W
+|4:0   |-        |Reserved                   |Reserved                                                                   |-
 |===
 
 ==== HRMEM IP Version Register (Offset: 0xF000)
@@ -355,13 +260,8 @@ HRMEM IP Version Registerは、HRMEM IPコアのバージョン管理レジス�
 .HRMEM IP Version Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |HRMEMMAJVER |HRMEM IP Major Version |HRMEMコアのMajor
-Versionを示します。 |RO
-
-|23:16 |HRMEMMINVER |HRMEM IP Minor Version |HRMEMコアのMinor
-Versionを示します。 |RO
-
-|15:0 |HRMEMPATVER |HRMEM IP Patch Version |HRMEMコアのPatch
-Versionを示します。 |RO
+|bit   |Symbol      |Field                  |Description                          |R/W
+|31:24 |HRMEMMAJVER |HRMEM IP Major Version |HRMEMコアのMajor Versionを示します。 |RO
+|23:16 |HRMEMMINVER |HRMEM IP Minor Version |HRMEMコアのMinor Versionを示します。 |RO
+|15:0  |HRMEMPATVER |HRMEM IP Patch Version |HRMEMコアのPatch Versionを示します。 |RO
 |===

--- a/modules/ROOT/pages/i2c_master_controller.adoc
+++ b/modules/ROOT/pages/i2c_master_controller.adoc
@@ -25,400 +25,222 @@ I2C Controllerは以下のベースアドレスに配置されています。
 |===
 
 .I2C Controller Register アドレスマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
-|Offset |Symbol |Register |Initial
-|0x0000 |I2CM_ENR |I2C Enable Register |0x00000000
-
-|0x0004 |I2CM_TXFIFOR |I2C TX FIFO Register |0x00000000
-
-|0x0008 |I2CM_RXFIFOR |I2C RX FIFO Register |0x00000000
-
-|0x000C |I2CM_BSR |I2C Bus Status Register |0x00000000
-
-|0x0010 |I2CM_ISR |I2C Interrupt Status Register |0x00000000
-
-|0x0014 |I2CM_IER |I2C Interrupt Enable Register |0x00000000
-
-|0x0018 |I2CM_FIFOSR |I2C FIFO Status Register |0x00000000
-
-|0x001C |I2CM_FIFORR |I2C FIFO Reset Register |0x00000000
-
-|0x0020 |I2CM_FTLSR |I2C FIFO Threshold Level Setting Register
-|0x00000000
-
-|0x0024 |I2CM_SCLTSR |I2C SCL Timeout Setting Register |0x00000000
-
-|0x0030 |I2CM_THDSTAR |I2C START Hold Timing Setting Register
-|0x000000EF
-
-|0x0034 |I2CM_TSUSTOR |I2C STOP Setup Timing Setting Register
-|0x000000EF
-
-|0x0038 |I2CM_TSUSTAR |I2C Repeated START Setup Timing Setting Register
-|0x00000117
-
-|0x003C |I2CM_THIGHR |I2C Clock High Timing Setting Register
-|0x000000E5
-
-|0x0040 |I2CM_THDDATR |I2C Data Hold Timing Setting Register
-|0x00000013
-
-|0x0044 |I2CM_TSUDATR |I2C Data Setup Timing Setting Register
-|0x000000E5
-
-|0x0048 |I2CM_TBUFR |I2C Bus Free Timing Setting Register |0x00000117
-
-|0x004C |I2CM_TBSMPLR |I2C Bus Sampling Timing Setting Register
-|0x00000000
-
-|0x0050 |I2CM_BFSR |I2C Bus Filter Setting Register |0x0000002F
-
-|0xF000 |I2CM_VER |I2C Controller IP Version Register |-
+|Offset |Symbol       |Register                                         |Initial
+|0x0000 |I2CM_ENR     |I2C Enable Register                              |0x00000000
+|0x0004 |I2CM_TXFIFOR |I2C TX FIFO Register                             |0x00000000
+|0x0008 |I2CM_RXFIFOR |I2C RX FIFO Register                             |0x00000000
+|0x000C |I2CM_BSR     |I2C Bus Status Register                          |0x00000000
+|0x0010 |I2CM_ISR     |I2C Interrupt Status Register                    |0x00000000
+|0x0014 |I2CM_IER     |I2C Interrupt Enable Register                    |0x00000000
+|0x0018 |I2CM_FIFOSR  |I2C FIFO Status Register                         |0x00000000
+|0x001C |I2CM_FIFORR  |I2C FIFO Reset Register                          |0x00000000
+|0x0020 |I2CM_FTLSR   |I2C FIFO Threshold Level Setting Register        |0x00000000
+|0x0024 |I2CM_SCLTSR  |I2C SCL Timeout Setting Register                 |0x00000000
+|0x0030 |I2CM_THDSTAR |I2C START Hold Timing Setting Register           |0x000000EF
+|0x0034 |I2CM_TSUSTOR |I2C STOP Setup Timing Setting Register           |0x000000EF
+|0x0038 |I2CM_TSUSTAR |I2C Repeated START Setup Timing Setting Register |0x00000117
+|0x003C |I2CM_THIGHR  |I2C Clock High Timing Setting Register           |0x000000E5
+|0x0040 |I2CM_THDDATR |I2C Data Hold Timing Setting Register            |0x00000013
+|0x0044 |I2CM_TSUDATR |I2C Data Setup Timing Setting Register           |0x000000E5
+|0x0048 |I2CM_TBUFR   |I2C Bus Free Timing Setting Register             |0x00000117
+|0x004C |I2CM_TBSMPLR |I2C Bus Sampling Timing Setting Register         |0x00000000
+|0x0050 |I2CM_BFSR    |I2C Bus Filter Setting Register                  |0x0000002F
+|0xF000 |I2CM_VER     |I2C Controller IP Version Register               |-
 |===
 
 ==== I2C Enable Register (Offset 0x0000)
 
 I2C Enable Registerは、I2C ControllerのEnable設定を行うレジスタです。
 
-EnableがOFFの時は、I2C ControllerはI2C Busに接続される FPGAのBufferを
-HiZ状態とし、一切の送受信を行いません。 EnableをONにすると、I2C
-BusがIdle状態の時に送受信が可能となります。
+EnableがOFFの時は、I2C ControllerはI2C Busに接続される FPGAのBufferを HiZ状態とし、一切の送受信を行いません。
+EnableをONにすると、I2C BusがIdle状態の時に送受信が可能となります。
 
 .I2C Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |I2CM_EN |I2C Enable |I2C ControllerのEnable設定を行います。0:
-Enable OFF 1: Enable ON |R/W
+|bit  |Symbol  |Field      |Description                          |R/W
+|31:1 |-       |Reserved   |Reserved                             |-
+|0    |I2CM_EN |I2C Enable |I2C ControllerのEnable設定を行います。 +
+                         0: Enable OFF +
+                         1: Enable ON                         |R/W
 |===
 
 ==== I2C TX FIFO Register (Offset 0x0004)
 
-I2C TX FIFO
-Registerは、I2Cデバイスへ送信するデータや、送受信データのフォーマットを設定するためのレジスタです。
+I2C TX FIFO Registerは、I2Cデバイスへ送信するデータや、送受信データのフォーマットを設定するためのレジスタです。
 
 レジスタに書き込む値は、転送状況によって変わります。
 
-転送開始の 1 Byte目は、I2CM_TXDATAフィールドの ビット7:1に 通信する
-I2Cデバイスのデバイスアドレスを書き込み、ビット0に R/W情報として
-次の転送サイクルが 送信モードの場合は"0",
-受信モードの場合は"1"を書き込みます。 ここで書き込まれた
-8ビットのデータは MSB側から順にそのまま I2Cバスに出力されます。
+転送開始の 1 Byte目は、I2CM_TXDATAフィールドの ビット7:1に 通信する I2Cデバイスのデバイスアドレスを書き込み、ビット0に R/W情報として 次の転送サイクルが 送信モードの場合は"0", 受信モードの場合は"1"を書き込みます。
+ここで書き込まれた 8ビットのデータは MSB側から順にそのまま I2Cバスに出力されます。
 
-1 Byte目にビット0に書き込まれた R/W情報によって、送信モード(R/W:
-0)となる場合、2 Byte目以降は I2CM_TXDATAに転送データを書き込みます。
-送信モードの場合、I2CM_TXDATAの書き込みと同時に I2CM_STOPか
-I2CM_RESTARTが "1"に書き込まれるまで転送が継続します。
-I2CM_TXDATAと共に
-I2CM_STOPが"1"に書き込まれた場合は、データ送信の完了後に STOP
-Conditionが送信され、I2CM_TXDATAと共に
-I2CM_RESTARTが"1"に書き込まれた場合は、データ送信の完了後に Repeated
-START Conditionが送信されます。 この状態になると、次の送信は 1
-Byte目の送信状態に戻ります。
+1 Byte目にビット0に書き込まれた R/W情報によって、送信モード(R/W: 0)となる場合、2 Byte目以降は I2CM_TXDATAに転送データを書き込みます。
+送信モードの場合、I2CM_TXDATAの書き込みと同時に I2CM_STOPか I2CM_RESTARTが "1"に書き込まれるまで転送が継続します。
+I2CM_TXDATAと共に I2CM_STOPが"1"に書き込まれた場合は、データ送信の完了後に STOP Conditionが送信され、I2CM_TXDATAと共に I2CM_RESTARTが"1"に書き込まれた場合は、データ送信の完了後に Repeated START Conditionが送信されます。
+この状態になると、次の送信は 1 Byte目の送信状態に戻ります。
 
-1 Byte目にビット0に書き込まれた R/W情報によって、受信モード(R/W:
-1)となる場合、2 Byte目の I2CM_TXDATAには受信データの
-Byte数を書き込みます。 この時、書き込む受信データの
-Byte数は、「実際に受信する Byte数 - 1」の値を設定します。
-また、最終Byteとなるデータの受信後に STOP Conditionまたは Repeated START
-Conditionを送信するため、I2CM_STOPか
-I2CM_RESTARTのどちらかのビットを"1"にセットします。
+1 Byte目にビット0に書き込まれた R/W情報によって、受信モード(R/W: 1)となる場合、2 Byte目の I2CM_TXDATAには受信データの Byte数を書き込みます。
+この時、書き込む受信データの Byte数は、「実際に受信する Byte数 - 1」の値を設定します。
+また、最終Byteとなるデータの受信後に STOP Conditionまたは Repeated START Conditionを送信するため、I2CM_STOPか I2CM_RESTARTのどちらかのビットを"1"にセットします。
 
 本レジスタの設定については「I2C通信操作手順例」も参照してください。
 
 .I2C TX FIFO Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:10 |- |Reserved |Reserved |-
-
-|9 |I2CM_RESTART |I2C Repeated START Condition |最終 Byteの転送完了後に
-I2C BusにRepeated START
-Conditionを送信する場合にセットするビットです。最終Byteの送受信後にRepeated
-START Conditionを挿入する場合は、このビットを"1"にセットします。 |WO
-
-|8 |I2CM_STOP |I2C STOP Condition |最終 Byteの転送完了後に I2C
-BusにSTOP
-Conditionを送信する場合にセットするビットです。最終Byteの送受信後にSTOP
-Conditionを送信する場合は、このビットを"1"にセットします。 |WO
-
-|7:0 |I2CM_TXDATA |I2C Tx Data
-|I2Cの送信データを設定します。このレジスタの書き込みデータは、送信モードでは送信データ,
-受信モードでは 受信データ Byte数となります。 |WO
+|bit   |Symbol       |Field                        |Description                                                                                                                                                                                  |R/W
+|31:10 |-            |Reserved                     |Reserved                                                                                                                                                                                     |-
+|9     |I2CM_RESTART |I2C Repeated START Condition |最終 Byteの転送完了後に I2C BusにRepeated START Conditionを送信する場合にセットするビットです。最終Byteの送受信後にRepeated START Conditionを挿入する場合は、このビットを"1"にセットします。 |WO
+|8     |I2CM_STOP    |I2C STOP Condition           |最終 Byteの転送完了後に I2C BusにSTOP Conditionを送信する場合にセットするビットです。最終Byteの送受信後にSTOP Conditionを送信する場合は、このビットを"1"にセットします。                     |WO
+|7:0   |I2CM_TXDATA  |I2C Tx Data                  |I2Cの送信データを設定します。このレジスタの書き込みデータは、送信モードでは送信データ, 受信モードでは 受信データ Byte数となります。                                                          |WO
 |===
 
 ==== I2C RX FIFO Register (Offset 0x0008)
 
-I2C RX FIFO
-Registerは、I2Cデバイスから受信したデータを読み出すためのレジスタです。
+I2C RX FIFO Registerは、I2Cデバイスから受信したデータを読み出すためのレジスタです。
 
-I2Cデバイスから受信データは RX FIFOに格納されます。 RX FIFOは 16
-Byte実装されており、このレジスタを読み出す事で RX
-FIFOに格納されたデータを 1 Byteずつデータを読み出す事ができます。
+I2Cデバイスから受信データは RX FIFOに格納されます。
+RX FIFOは 16 Byte実装されており、このレジスタを読み出す事で RX FIFOに格納されたデータを 1 Byteずつデータを読み出す事ができます。
 
 .I2C RX FIFO Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |I2CM_RXDATA |I2C Rx Data
-|I2Cデバイスから受信したデータを読み出すためのフィールドです。 |RO
+|bit  |Symbol      |Field       |Description                                                   |R/W
+|31:8 |-           |Reserved    |Reserved                                                      |-
+|7:0  |I2CM_RXDATA |I2C Rx Data |I2Cデバイスから受信したデータを読み出すためのフィールドです。 |RO
 |===
 
 ==== I2C Bus Status Register (Offset 0x000C)
 
-I2C Bus Status Registerは、I2C
-Busのステータスを確認するためのレジスタです。
-I2C_SELFBUSY,I2C_OTHERBUSYビットがともに"0"を示す時、I2C
-BusがIdle状態であることを示します。
+I2C Bus Status Registerは、I2C Busのステータスを確認するためのレジスタです。
+I2C_SELFBUSY,I2C_OTHERBUSYビットがともに"0"を示す時、I2C BusがIdle状態であることを示します。
 
 .I2C Bus Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:2 |- |Reserved |Reserved |-
-
-|1 |I2CM_OTHERBUSY |I2C Bus Busy by Other Communication |同一I2C
-Busのバス状態を示すビットです。他のマスターデバイスがI2C通信中の時、このビットは"1"を示します。このビットはI2C
-EnableがOFFの状態でも機能します。 |RO
-
-|0 |I2CM_SELFBUSY |I2C Bus Busy by Self Communication |I2C
-ControllerのI2Cバス状態を示すビットです。自身のI2C
-ControllerがI2C通信中、このビットは"1"を示します。 |RO
+|bit  |Symbol         |Field                               |Description                                                                                                                                              |R/W
+|31:2 |-              |Reserved                            |Reserved                                                                                                                                                 |-
+|1    |I2CM_OTHERBUSY |I2C Bus Busy by Other Communication |同一I2C Busのバス状態を示すビットです。他のマスターデバイスがI2C通信中の時、このビットは"1"を示します。このビットはI2C EnableがOFFの状態でも機能します。 |RO
+|0    |I2CM_SELFBUSY  |I2C Bus Busy by Self Communication  |I2C ControllerのI2Cバス状態を示すビットです。自身のI2C ControllerがI2C通信中、このビットは"1"を示します。                                                |RO
 |===
 
 ==== I2C Interrupt Status Register (Offset: 0x0010)
 
-I2C Interrupt Status Registerは、I2C
-Controllerの割り込みステータスレジスタです。
+I2C Interrupt Status Registerは、I2C Controllerの割り込みステータスレジスタです。
 それぞれのビットは"1"をセットすると、割り込みをクリアする事ができます。
 
 .I2C Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:13 |- |Reserved |Reserved |-
-
-|12 |I2CM_SCLTO |I2C SCL Timeout |通信中のSCL
-Timeoutが発生した事を示すビットです。I2CデバイスによるSCLのクロックストレッチ機能等により、通信中にSCLがLoとなっている時間が
-I2C SCL Timeout Setting
-RegisterのI2CM_SCLTOPRODフィールドの設定値を超えたとき本ビットが"1"にセットされます。
-|R/WC
-
-|11 |I2CM_RXFIFOUDF |I2C RX FIFO Underflow |RX FIFOの
-Underflowが発生したことを示すビットです。RX FIFOが Emptyの時に、I2C RX
-FIFO Registerの読み出しが行われたとき、本ビットが"1"にセットされます。
-|R/WC
-
-|10 |I2CM_TXFIFOOVF |I2C TX FIFO Overflow |TX FIFOの
-Overflowが発生したことを示すビットです。TX FIFOが Fullの時に、I2C TX
-FIFO Registerへの書き込みを行ったとき、本ビットが"1"にセットされます。
-|R/WC
-
-|9 |I2CM_BITER |I2C BIT Error |BIT
-Errorが発生したことを示すビットです。Lowレベルのビットを送信した時に、異なるレベルが検出された場合に本ビットが"1"にセットされます。BIT
-Errorを検出すると、I2C Controllerは以降のデータ送信を停止し、STOP
-Conditionを送信してからI2C EnableをOffにしてIdle状態に戻ります。 |R/WC
-
-|8 |I2CM_ACKER |I2C ACK Error |ACK
-Errorが発生したことを示すビットです。送信中に
-ACKビットでLowレベルが検出出来なかった場合に本ビットが"1"にセットされます。ACK
-Errorを検出すると、I2C Controllerは以降のデータ送信を停止し、STOP
-Conditionを送信してからI2C EnableをOffにしてIdle状態に戻ります。 |R/WC
-
-|7:6 |- |Reserved |Reserved |-
-
-|5 |I2CM_RXFIFOOTH |I2C RX FIFO Over Threshold |RX
-FIFOに格納されるデータが閾値を上回ったことを示すビットです。データ量が
-I2C FIFO Threshold Level Setting Registerの
-I2CM_RXFIFOOTHLフィールドの設定値より多くなった場合に本ビットが"1"にセットされます。
-|R/WC
-
-|4 |I2CM_TXFIFOUTH |I2C TX FIFO Under Threshold |TX
-FIFOに格納されるデータが閾値を下回ったことを示すビットです。データ量が
-I2C FIFO Threshold Level Setting Registerの
-I2CM_TXFIFOUTHLフィールドの設定値より少なくなった場合に本ビットが"1"にセットされます。
-|R/WC
-
-|3:2 |- |Reserved |Reserved |-
-
-|1 |I2CM_ARBLST |I2C Arbitration Lost |送信中にArbitration
-Lostが発生した事を示すビットです。送信中に他の I2C
-Masterと送信が競合したことによる調停制御で送信を停止した場合、本ビットが"1"にセットされます。Arbitration
-Lostを検出すると、I2C Controllerは I2C
-EnableをOffにしてIdle状態に戻ります。 |R/WC
-
-|0 |I2CM_COMP |I2C Complete |I2C
-ControllerによるI2C通信が正常に完了した事を示すビットです。I2C通信の正常完了で
-I2C BusにSTOP
-Conditionを送信した時、本ビットが"1”にセットされます。Arbitration
-LostやError検出によるSTOP
-Conditionの送信時には本ビットはセットされません。 |R/WC
+|bit   |Symbol         |Field                       |Description                                                                                                                                                                                                                                                 |R/W
+|31:13 |-              |Reserved                    |Reserved                                                                                                                                                                                                                                                    |-
+|12    |I2CM_SCLTO     |I2C SCL Timeout             |通信中のSCL Timeoutが発生した事を示すビットです。I2CデバイスによるSCLのクロックストレッチ機能等により、通信中にSCLがLoとなっている時間が I2C SCL Timeout Setting RegisterのI2CM_SCLTOPRODフィールドの設定値を超えたとき本ビットが"1"にセットされます。      |R/WC
+|11    |I2CM_RXFIFOUDF |I2C RX FIFO Underflow       |RX FIFOの Underflowが発生したことを示すビットです。RX FIFOが Emptyの時に、I2C RX FIFO Registerの読み出しが行われたとき、本ビットが"1"にセットされます。                                                                                                     |R/WC
+|10    |I2CM_TXFIFOOVF |I2C TX FIFO Overflow        |TX FIFOの Overflowが発生したことを示すビットです。TX FIFOが Fullの時に、I2C TX FIFO Registerへの書き込みを行ったとき、本ビットが"1"にセットされます。                                                                                                       |R/WC
+|9     |I2CM_BITER     |I2C BIT Error               |BIT Errorが発生したことを示すビットです。Lowレベルのビットを送信した時に、異なるレベルが検出された場合に本ビットが"1"にセットされます。
+BIT Errorを検出すると、I2C Controllerは以降のデータ送信を停止し、STOP Conditionを送信してからI2C EnableをOffにしてIdle状態に戻ります。                                                                                                                                                                           |R/WC
+|8     |I2CM_ACKER     |I2C ACK Error               |ACK Errorが発生したことを示すビットです。送信中に ACKビットでLowレベルが検出出来なかった場合に本ビットが"1"にセットされます。
+ACK Errorを検出すると、I2C Controllerは以降のデータ送信を停止し、STOP Conditionを送信してからI2C EnableをOffにしてIdle状態に戻ります。                                                                                                                                                                           |R/WC
+|7:6   |-              |Reserved                    |Reserved                                                                                                                                                                                                                                                    |-
+|5     |I2CM_RXFIFOOTH |I2C RX FIFO Over Threshold  |RX FIFOに格納されるデータが閾値を上回ったことを示すビットです。データ量が I2C FIFO Threshold Level Setting Registerの I2CM_RXFIFOOTHLフィールドの設定値より多くなった場合に本ビットが"1"にセットされます。                                                  |R/WC
+|4     |I2CM_TXFIFOUTH |I2C TX FIFO Under Threshold |TX FIFOに格納されるデータが閾値を下回ったことを示すビットです。データ量が I2C FIFO Threshold Level Setting Registerの I2CM_TXFIFOUTHLフィールドの設定値より少なくなった場合に本ビットが"1"にセットされます。                                                |R/WC
+|3:2   |-              |Reserved                    |Reserved                                                                                                                                                                                                                                                    |-
+|1     |I2CM_ARBLST    |I2C Arbitration Lost        |送信中にArbitration Lostが発生した事を示すビットです。送信中に他の I2C Masterと送信が競合したことによる調停制御で送信を停止した場合、本ビットが"1"にセットされます。Arbitration Lostを検出すると、I2C Controllerは I2 EnableをOffにしてIdle状態に戻ります。 |R/WC
+|0     |I2CM_COMP      |I2C Complete                |I2C ControllerによるI2C通信が正常に完了した事を示すビットです。I2C通信の正常完了で I2C BusにSTOP Conditionを送信した時、本ビットが"1”にセットされます。Arbitration LostやError検出によるSTOP Conditionの送信時には本ビットはセットされません。             |R/WC
 |===
 
 ==== I2C Interrupt Enable Register (Offset: 0x0014)
 
-I2C Interrupt Enable Registerは、I2C
-Controllerの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
+I2C Interrupt Enable Registerは、I2C Controllerの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
 
-Interrupt Enable Registerのビットが
-"1"にセットした時、その割り込み要因に対応する Interrupt Status
-Registerのビットが "1"にセットされた時、レベル割り込みが出力します。
+Interrupt Enable Registerのビットが "1"にセットした時、その割り込み要因に対応する Interrupt Status Registerのビットが "1"にセットされた時、レベル割り込みが出力します。
 
 .I2C Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:13 |- |Reserved |Reserved |-
-
-|12 |I2CM_SCLTOENB |I2C SCL Timeout Enable
-|I2CM_SCLTOイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|11 |I2CM_RXFIFOUDFENB |I2C RX FIFO Underflow Enable
-|I2CM_RXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|10 |I2CM_TXFIFOOVFENB |I2C TX FIFO Overflow Enable
-|I2CM_TXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|9 |I2CM_BITERENB |I2C BIT Error Enable
-|I2CM_BITERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|8 |I2CM_ACKERENB |I2C ACK Error Enable
-|I2CM_ACKERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|7:6 |- |Reserved |Reserved |-
-
-|5 |I2CM_RXFIFOOTHENB |I2C RX FIFO Over Threshold Enable
-|I2CM_RXFIFOOTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|4 |I2CM_TXFIFOUTHENB |I2C TX FIFO Under Threshold Enable
-|I2CM_TXFIFOUTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|3:2 |- |Reserved |Reserved |-
-
-|1 |I2CM_ARBLSTENB |I2C Arbitration Lost Enable
-|I2CM_ARBLSTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|0 |I2CM_COMPENB |I2C Complete Enable
-|I2CM_COMPイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
+|bit   |Symbol            |Field                              |Description                                                                       |R/W
+|31:13 |-                 |Reserved                           |Reserved                                                                          |-
+|12    |I2CM_SCLTOENB     |I2C SCL Timeout Enable             |I2CM_SCLTOイベントが発生した時に割り込み信号を発生させるかどうかを設定します。    |R/W
+|11    |I2CM_RXFIFOUDFENB |I2C RX FIFO Underflow Enable       |I2CM_RXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|10    |I2CM_TXFIFOOVFENB |I2C TX FIFO Overflow Enable        |I2CM_TXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|9     |I2CM_BITERENB     |I2C BIT Error Enable               |I2CM_BITERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。    |R/W
+|8     |I2CM_ACKERENB     |I2C ACK Error Enable               |I2CM_ACKERイベントが発生した時に割り込み信号を発生させるかどうかを設定します。    |R/W
+|7:6   |-                 |Reserved                           |Reserved                                                                          |-
+|5     |I2CM_RXFIFOOTHENB |I2C RX FIFO Over Threshold Enable  |I2CM_RXFIFOOTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|4     |I2CM_TXFIFOUTHENB |I2C TX FIFO Under Threshold Enable |I2CM_TXFIFOUTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|3:2   |-                 |Reserved                           |Reserved                                                                          |-
+|1     |I2CM_ARBLSTENB    |I2C Arbitration Lost Enable        |I2CM_ARBLSTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。   |R/W
+|0     |I2CM_COMPENB      |I2C Complete Enable                |I2CM_COMPイベントが発生した時に割り込み信号を発生させるかどうかを設定します。     |R/W
 |===
 
 ==== I2C FIFO Status Register (Offset 0x0018)
 
-I2C FIFO Status Registerは、TX FIFO/RX
-FIFOに格納されているデータ量を読み出すためのレジスタです。
+I2C FIFO Status Registerは、TX FIFO/RX FIFOに格納されているデータ量を読み出すためのレジスタです。
 
 .I2C FIFO Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |- |Reserved |Reserved |-
-
-|20:16 |I2CM_RXFIFOCAP |I2C RX FIFO Capacity |RX
-FIFOに格納されているデータ量を示すフィールドです。 |RO
-
-|15:5 |- |Reserved |Reserved |-
-
-|4:0 |I2CM_TXFIFOCAP |I2C TX FIFO Capacity |TX
-FIFOに格納されているデータ量を示すフィールドです。 |RO
+|bit   |Symbol         |Field                |Description                                           |R/W
+|31:21 |-              |Reserved             |Reserved                                              |-
+|20:16 |I2CM_RXFIFOCAP |I2C RX FIFO Capacity |RX FIFOに格納されているデータ量を示すフィールドです。 |RO
+|15:5  |-              |Reserved             |Reserved                                              |-
+|4:0   |I2CM_TXFIFOCAP |I2C TX FIFO Capacity |TX FIFOに格納されているデータ量を示すフィールドです。 |RO
 |===
 
 ==== I2C FIFO Reset Register (Offset 0x001C)
 
-I2C FIFO Reset Registerは、TX FIFO/RX
-FIFOのリセットを行うためのレジスタです。
+I2C FIFO Reset Registerは、TX FIFO/RX FIFOのリセットを行うためのレジスタです。
 何らかの理由によりFIFOのクリアを行いたい場合にこのレジスタを使用します。
 
 .I2C FIFO Reset Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |I2CM_RXFIFORST |I2C RX FIFO Reset |RX
-FIFOをリセットするためのビットです。本ビットに"1"をセットすると、RX
-FIFOがリセットされデータが消去されます。 |WO
-
-|15:1 |- |Reserved |Reserved |-
-
-|0 |I2CM_TXFIFORST |I2C TX FIFO Reset |TX
-FIFOをリセットするためのビットです。本ビットに"1"をセットすると、TX
-FIFOがリセットされデータが消去されます。 |WO
+|bit   |Symbol         |Field             |Description                                                                                                     |R/W
+|31:17 |-              |Reserved          |Reserved                                                                                                        |-
+|16    |I2CM_RXFIFORST |I2C RX FIFO Reset |RX FIFOをリセットするためのビットです。本ビットに"1"をセットすると、RX FIFOがリセットされデータが消去されます。 |WO
+|15:1  |-              |Reserved          |Reserved                                                                                                        |-
+|0     |I2CM_TXFIFORST |I2C TX FIFO Reset |TX FIFOをリセットするためのビットです。本ビットに"1"をセットすると、TX FIFOがリセットされデータが消去されます。 |WO
 |===
 
 ==== I2C FIFO Threshold Level Setting Register (Offset 0x0020)
 
-I2C FIFO Threshold Level Registerは、TX FIFO/RX
-FIFOのデータ量に応じた割り込み出力を行うための設定レジスタです。
+I2C FIFO Threshold Level Registerは、TX FIFO/RX FIFOのデータ量に応じた割り込み出力を行うための設定レジスタです。
 
 .I2C FIFO Threshold Level Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |- |Reserved |Reserved |-
-
-|20:16 |I2CM_RXFIFOOTHL |I2C RX FIFO Over Threshold Level
-|I2CM_RXFIFOOTH割り込みを発生させるRX
-FIFOのデータ格納量の閾値を設定するためのフィールドです。本フィールドに
-0または最大値を設定した場合
-I2CM_RXFIFOOTHは無効となり、割り込みは発生しません。 |R/W
-
-|15:5 |- |Reserved |Reserved |-
-
-|4:0 |I2CM_TXFIFOUTHL |I2C TX FIFO Under Threshold Level
-|I2CM_TXFIFOUTH割り込みを発生させるTX
-FIFOのデータ格納量の閾値を設定するためのフィールドです。本フィールドに
-0または最大値を設定した場合
-I2CM_TXFIFOUTHは無効となり、割り込みは発生しません。 |R/W
+|bit   |Symbol          |Field                             |Description                                                                                                                                                                                  |R/W
+|31:21 |-               |Reserved                          |Reserved                                                                                                                                                                                     |-
+|20:16 |I2CM_RXFIFOOTHL |I2C RX FIFO Over Threshold Level  |I2CM_RXFIFOOTH割り込みを発生させるRX FIFOのデータ格納量の閾値を設定するためのフィールドです。本フィールドに 0または最大値を設定した場合 I2CM_RXFIFOOTHは無効となり、割り込みは発生しません。 |R/W
+|15:5  |-               |Reserved                          |Reserved                                                                                                                                                                                     |-
+|4:0   |I2CM_TXFIFOUTHL |I2C TX FIFO Under Threshold Level |I2CM_TXFIFOUTH割り込みを発生させるTX FIFOのデータ格納量の閾値を設定するためのフィールドです。本フィールドに 0または最大値を設定した場合 I2CM_TXFIFOUTHは無効となり、割り込みは発生しません。 |R/W
 |===
 
 ==== I2C SCL Timeout Setting Register (Offset 0x0024)
 
-I2C SCL Timeout Setting Registerは、SCL Timeout割り込み発生させるための
-SCL Timeout時間を設定するレジスタです。
+I2C SCL Timeout Setting Registerは、SCL Timeout割り込み発生させるための SCL Timeout時間を設定するレジスタです。
 
 .I2C SCL Timeout Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_SCLTOPROD |I2C SCL Timeout Period
-|I2CM_SCLTO割り込みを発生させる SCL
-Low期間を設定するためのフィールドです。このフィールドには、1 us単位の
-Timeout時間を設定します。本フィールドを0に設定した場合は
-I2CM_SCLTOは無効となり、割り込みは発生しません。 |R/W
+|bit   |Symbol         |Field                  |Description                                                                                                                                                                                                       |R/W
+|31:16 |-              |Reserved               |Reserved                                                                                                                                                                                                          |-
+|15:0  |I2CM_SCLTOPROD |I2C SCL Timeout Period |I2CM_SCLTO割り込みを発生させる SCL Low期間を設定するためのフィールドです。このフィールドには、1 us単位の Timeout時間を設定します。本フィールドを0に設定した場合は I2CM_SCLTOは無効となり、割り込みは発生しません。|R/W
 |===
 
 ==== I2C START Hold Timing Setting Register (Offset 0x0030)
 
-I2C START Hold Timing Setting Registerは、I2C規格における START/Repeated
-START Conditionの Hold時間を設定するためのレジスタです。
-このレジスタは、I2C Enable
-RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C START Hold Timing Setting Registerは、I2C規格における START/Repeated START Conditionの Hold時間を設定するためのレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C START Hold Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_THDSTA |I2C START Hold Time |START
-ConditionのHold時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。
-|R/W
+|bit   |Symbol      |Field               |Description                                                                                                                    |R/W
+|31:16 |-           |Reserved            |Reserved                                                                                                                       |-
+|15:0  |I2CM_THDSTA |I2C START Hold Time |START ConditionのHold時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。|R/W
 |===
 
 レジスタ設定によるSTART Hold Time(tHDSTA)は、次の式で計算できます。
@@ -432,19 +254,15 @@ tHDSTA [s] = System\ Clock\ period\ [s] \times \left(I2CM\_THDSTA +1\right)
 
 ==== I2C STOP Setup Timing Setting Register (Offset 0x0034)
 
-I2C STOP Setup Timing Setting Registerは、I2C規格における STOP
-ConditionのSetup時間を設定するためのレジスタです。 このレジスタは、I2C
-Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C STOP Setup Timing Setting Registerは、I2C規格における STOP ConditionのSetup時間を設定するためのレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C STOP Setup Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_TSUSTO |I2C STOP Setup Time |STOP
-ConditionのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。
-|R/W
+|bit   |Symbol      |Field               |Description                                                                                                                    |R/W
+|31:16 |-           |Reserved            |Reserved                                                                                                                       |-
+|15:0  |I2CM_TSUSTO |I2C STOP Setup Time |STOP ConditionのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。|R/W
 |===
 
 レジスタ設定によるSTOP Setup Time(tSUSTO)は、次の式で計算できます。
@@ -454,8 +272,7 @@ ConditionのSetup時間を設定するフィールドです。このフィール
 tSUSTO [s] = System\ Clock\ period\ [s] \times \left(I2CM\_TSUSTO +1\right)
 ++++
 
-マルチマスター構成となる場合、または、クロックストレッチ機能を持った
-I2Cデバイスと接続して通信する場合、このレジスタは"0x3"以上に設定してください。
+マルチマスター構成となる場合、または、クロックストレッチ機能を持った I2Cデバイスと接続して通信する場合、このレジスタは"0x3"以上に設定してください。
 
 このレジスタの設定を行う場合は「I2Cタイミングパラメータの設定」も参照してください。
 
@@ -469,43 +286,33 @@ RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 .I2C Repeated START Setup Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_TSUSTA |I2C Repeated START Setup Time |Repeated START
-ConditionのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。
-|R/W
+|bit   |Symbol      |Field                         |Description                                                                                                                              |R/W
+|31:16 |-           |Reserved                      |Reserved                                                                                                                                 |-
+|15:0  |I2CM_TSUSTA |I2C Repeated START Setup Time |Repeated START ConditionのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。|R/W
 |===
 
-レジスタ設定によるRepeated START Setup
-Time(tSUSTA)は、次の式で計算できます。
+レジスタ設定によるRepeated START Setup Time(tSUSTA)は、次の式で計算できます。
 
 [stem]
 ++++
 tSUSTA [s] = System\ Clock\ period\ [s] \times \left(I2CM\_TSUSTA +1\right)
 ++++
 
-マルチマスター構成となる場合、または、クロックストレッチ機能を持った
-I2Cデバイスと接続して通信する場合、このレジスタは
-0x3以上に設定してください。
+マルチマスター構成となる場合、または、クロックストレッチ機能を持った I2Cデバイスと接続して通信する場合、このレジスタは 0x3以上に設定してください。
 
 このレジスタの設定を行う場合は「I2Cタイミングパラメータの設定」も参照してください。
 
 ==== I2C Clock High Timing Setting Register (Offset 0x003C)
 
-I2C Clock High Timing Setting Registerは、I2C規格における
-SCLのHigh時間を設定するレジスタです。 このレジスタは、I2C Enable
-RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C Clock High Timing Setting Registerは、I2C規格における SCLのHigh時間を設定するレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C Clock High Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_THIGH |I2C SCL High period
-|SCLのHigh時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。
-|R/W
+|bit   |Symbol     |Field               |Description                                                                                                         |R/W
+|31:16 |-          |Reserved            |Reserved                                                                                                            |-
+|15:0  |I2CM_THIGH |I2C SCL High period |SCLのHigh時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によってタイミングを設定します。 |R/W
 |===
 
 レジスタ設定によるSCLのHigh時間(tHIGH)は、次の式で計算できます。
@@ -516,24 +323,19 @@ tHIGH\ [s] = System\ Clock\ period\ [s] \times \left(I2CM\_THIGH +1\right)
 ++++
 
 このレジスタは必ず"0x4"以上に設定する必要があります。
-
 このレジスタの設定を行う場合は「I2Cタイミングパラメータの設定」も参照してください。
 
 ==== I2C Data Hold Timing Setting Register (Offset 0x0040)
 
-I2C Data Hold Timing Setting Registerは、I2C規格における
-データのHold時間を設定するためのレジスタです。 このレジスタは、I2C
-Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C Data Hold Timing Setting Registerは、I2C規格におけるデータのHold時間を設定するためのレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C Data Hold Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_THDDAT |I2C Data Hold Time
-|データのHold時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。
-|R/W
+|bit   |Symbol      |Field              |Description                                                                                               |R/W
+|31:16 |-           |Reserved           |Reserved                                                                                                  |-
+|15:0  |I2CM_THDDAT |I2C Data Hold Time |データのHold時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。|R/W
 |===
 
 レジスタ設定によるData Hold Time(tHDDAT)は、次の式で計算できます。
@@ -543,26 +345,21 @@ Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です�
 tHDDAT\ [s] = System\ Clock\ period\ [s] \times \left(I2CM\_THDDAT +1\right)
 ++++
 
-マルチマスター構成となる場合、または、クロックストレッチ機能を持った
-I2Cデバイスと接続して通信する場合、このレジスタは"0x3"以上に設定してください。
+マルチマスター構成となる場合、または、クロックストレッチ機能を持った I2Cデバイスと接続して通信する場合、このレジスタは"0x3"以上に設定してください。
 
 このレジスタの設定を行う場合は「I2Cタイミングパラメータの設定」も参照してください。
 
 ==== I2C Data Setup Timing Setting Register (Offset 0x0044)
 
-I2C Data Setup Timing Setting Registerは、I2C規格における
-データのSetup時間を設定するためのレジスタです。 このレジスタは、I2C
-Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C Data Setup Timing Setting Registerは、I2C規格におけるデータのSetup時間を設定するためのレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C Data Setup Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_TSUDAT |I2C Data Setup Time
-|データのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。
-|R/W
+|bit   |Symbol      |Field               |Description                                                                                                 |R/W
+|31:16 |-           |Reserved            |Reserved                                                                                                    |-
+|15:0  |I2CM_TSUDAT |I2C Data Setup Time |データのSetup時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。 |R/W
 |===
 
 レジスタ設定によるData Setup Time(tSUDAT)は、次の式で計算できます。
@@ -572,8 +369,7 @@ Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です�
 tSUDAT\ [s] = System\ Clock\ period\ [s] \times \left(I2CM\_TSUDAT +1\right)
 ++++
 
-また、SCLのLow時間(tLOW)は、Data Hold TimeとData Setup
-Timeの和により決定されます。
+また、SCLのLow時間(tLOW)は、Data Hold TimeとData Setup Timeの和により決定されます。
 
 [stem]
 ++++
@@ -584,20 +380,15 @@ tLOW\ [s] = tHDDAT\ [s] + tSUDAT\ [s]
 
 ==== I2C Bus Free Timing Setting Register (Offset 0x0048)
 
-I2C Bus Free Timing Setting Registerは、I2C規格における ConditionとSTART
-Condition間のBus開放時間を設定するためのレジスタです。
-このレジスタは、I2C Enable
-RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+I2C Bus Free Timing Setting Registerは、I2C規格における ConditionとSTART Condition間のBus開放時間を設定するためのレジスタです。
+このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C Bus Free Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_TBUF |I2C Bus Free Time |I2C
-Busの開放時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。
-|R/W
+|bit   |Symbol    |Field             |Description                                                                                                 |R/W
+|31:16 |-         |Reserved          |Reserved                                                                                                    |-
+|15:0  |I2CM_TBUF |I2C Bus Free Time |I2C Busの開放時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。 |R/W
 |===
 
 レジスタ設定によるBus Free Time(tBUF)は、次の式で計算できます。
@@ -611,22 +402,16 @@ tBUF\ [s] = System\ Clock\ period\ [s] \times \left(I2CM\_TBUF +1\right)
 
 ==== I2C Bus Sampling Timing Setting Register (Offset 0x004C)
 
-I2C Bus Sampling Timing Setting
-Registerは、受信データのサンプリングタイミングを設定するためのレジスタです。
+I2C Bus Sampling Timing Setting Registerは、受信データのサンプリングタイミングを設定するためのレジスタです。
 
-SCLの立ち上がりタイミングを起点として、このレジスタに設定した遅延時間後に
-SDA信号のサンプリングを行います。 このレジスタは、I2C Enable
-RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
+SCLの立ち上がりタイミングを起点として、このレジスタに設定した遅延時間後に SDA信号のサンプリングを行います。 このレジスタは、I2C Enable RegisterのI2CM_ENビットが"0"の時のみ書き込みが可能です。
 
 .I2C Bus Sampling Timing Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |I2CM_SMPLDLY |I2C Sampling Delay
-|SDAをサンプリングするタイミングを設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。
-|R/W
+|bit   |Symbol       |Field              |Description                                                                                                              |R/W
+|31:16 |-            |Reserved           |Reserved                                                                                                                 |-
+|15:0  |I2CM_SMPLDLY |I2C Sampling Delay |SDAをサンプリングするタイミングを設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。|R/W
 |===
 
 レジスタ設定によるSDAのサンプリング遅延時間は、次の式で計算できます。
@@ -638,23 +423,17 @@ SDA Sampling Delay\ [s] = System\ Clock\ period\ [s] \times I2CM\_SMPLDLY
 
 ==== I2C Bus Filter Setting Register (Offset 0x0050)
 
-I2C Bus Filter Setting Registerは、I2C
-Bus信号の入力信号のフィルタ時間を設定するためのレジスタです。
+I2C Bus Filter Setting Registerは、I2C Bus信号の入力信号のフィルタ時間を設定するためのレジスタです。
 
-I2C
-Busから入力される信号は、このレジスタで設定された値で動作するデジタルフィルターを介して後段に信号を伝えます。
-フィルタ時間は、I2C規格で定められる「SDA信号と SCL信号の立ち上がり時間
-(tr)」、「SDA信号と SCL信号の立ち下がり時間 (tf)」値を元に設定します。
+I2C Busから入力される信号は、このレジスタで設定された値で動作するデジタルフィルターを介して後段に信号を伝えます。
+フィルタ時間は、I2C規格で定められる「SDA信号と SCL信号の立ち上がり時間 (tr)」、「SDA信号と SCL信号の立ち下がり時間 (tf)」値を元に設定します。
 
 .I2C Bus Filter Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |I2CM_FLTCYC |I2C Filtering Time |SDA, SCL信号のレベルが
-遷移するときのフィルタリング時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。
-|R/W
+|bit  |Symbol      |Field              |Description                                                                                                                                      |R/W
+|31:8 |-           |Reserved           |Reserved                                                                                                                                         |-
+|7:0  |I2CM_FLTCYC |I2C Filtering Time |SDA, SCL信号のレベルが 遷移するときのフィルタリング時間を設定するフィールドです。このフィールドはシステムクロックのサイクル数によって設定します。|R/W
 |===
 
 I2CM_FLTCYCの値は、以下の計算で算出される値を設定します。
@@ -674,15 +453,10 @@ I2C Controller IPコアバージョンの管理レジスタです。
 .I2C Controller IP Version Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |MAJVER |I2C Controller IP Major Version |I2C
-ControllerコアのMajor Versionを示します。 |RO
-
-|23:16 |MINVER |I2C Controller IP Minor Version |I2C
-ControllerコアのMinor Versionを示します。 |RO
-
-|15:0 |PATVER |I2C Controller IP Patch Version |I2C
-ControllerコアのPatch Versionを示します。 |RO
+|bit   |Symbol |Field                           |Description                                   |R/W
+|31:24 |MAJVER |I2C Controller IP Major Version |I2C ControllerコアのMajor Versionを示します。 |RO
+|23:16 |MINVER |I2C Controller IP Minor Version |I2C ControllerコアのMinor Versionを示します。 |RO
+|15:0  |PATVER |I2C Controller IP Patch Version |I2C ControllerコアのPatch Versionを示します。 |RO
 |===
 
 === I2Cアクセス手順
@@ -740,67 +514,43 @@ I2Cクロック(SCL)のLow期間(tLOW)は、I2Cデータ(SDA)のSetup/Hold時間
 .I2C Controller タイミングパラメータの設定例 (システムクロック 96 MHz)
 [cols=",,,",options="header",]
 |===
-|Parameter |Standard-mode(100Kb/s) |Fast-mode(400Kb/s) |Fast-mode
-Plus(1Mb/s)
-|I2CM_THDSTA[15:0] |0x01DF(5us) |0x0063(1.04us) |0x0027(0.42us)
-
-|I2CM_TSUSTO[15:0] |0x01DF(5us) |0x0063(1.04us) |0x0027(0.42us)
-
-|I2CM_TSUSTA[15:0] |0x022F(5.83us) |0x0063(1.04us) |0x0027(0.42us)
-
-|I2CM_THIGH[15:0] |0x01CB(4.79us) |0x0072(1.20us) |0x002D(0.48us)
-
-|I2CM_THDDAT[15:0] |0x0027(0.42us) |0x0009(0.10us) |0x0003(0.04us)
-
-|I2CM_TSUDAT[15:0] |0x01CB(4.79us) |0x0072(1.20us) |0x002D(0.48us)
-
-|I2CM_TBUF[15:0] |0x022F(5.83us) |0x008B(1.46us) |0x0037(0.58us)
-
-|I2CM_FLTCYC[7:0] |0x5F(1000ns) |0x1C(302ns) |0x0B(125ns)
+|Parameter         |Standard-mode(100Kb/s) |Fast-mode(400Kb/s) |Fast-mode Plus(1Mb/s)
+|I2CM_THDSTA[15:0] |0x01DF(5us)            |0x0063(1.04us)     |0x0027(0.42us)
+|I2CM_TSUSTO[15:0] |0x01DF(5us)            |0x0063(1.04us)     |0x0027(0.42us)
+|I2CM_TSUSTA[15:0] |0x022F(5.83us)         |0x0063(1.04us)     |0x0027(0.42us)
+|I2CM_THIGH[15:0]  |0x01CB(4.79us)         |0x0072(1.20us)     |0x002D(0.48us)
+|I2CM_THDDAT[15:0] |0x0027(0.42us)         |0x0009(0.10us)     |0x0003(0.04us)
+|I2CM_TSUDAT[15:0] |0x01CB(4.79us)         |0x0072(1.20us)     |0x002D(0.48us)
+|I2CM_TBUF[15:0]  |0x022F(5.83us)          |0x008B(1.46us)     |0x0037(0.58us)
+|I2CM_FLTCYC[7:0] |0x5F(1000ns)            |0x1C(302ns)        |0x0B(125ns)
 |===
 
 .I2C Controller タイミングパラメータの設定例 (システムクロック 48 MHz)
 [cols=",,,",options="header",]
 |===
-|Parameter |Standard-mode(100Kb/s)[default] |Fast-mode(400Kb/s)
-|Fast-mode Plus(1Mb/s)
-|I2CM_THDSTA[15:0] |0x00EF(5us) |0x0031(1.04us) |0x0013(0.42us)
-
-|I2CM_TSUSTO[15:0] |0x00EF(5us) |0x0031(1.04us) |0x0013(0.42us)
-
-|I2CM_TSUSTA[15:0] |0x0117(5.83us) |0x0031(1.04us) |0x0013(0.42us)
-
-|I2CM_THIGH[15:0] |0x00E5(4.79us) |0x0039(1.21us) |0x0015(0.46us)
-
-|I2CM_THDDAT[15:0] |0x0013(0.42us) |0x0004(0.10us) |0x0003(0.08us)
-
-|I2CM_TSUDAT[15:0] |0x00E5(4.79us) |0x0039(1.21us) |0x0015(0.46us)
-
-|I2CM_TBUF[15:0] |0x0117(5.83us) |0x0045(1.46us) |0x001B(0.58us)
-
-|I2CM_FLTCYC[7:0] |0x2F(1000ns) |0x0E(312ns) |0x05(125ns)
+|Parameter         |Standard-mode(100Kb/s)[default] |Fast-mode(400Kb/s) |Fast-mode Plus(1Mb/s)
+|I2CM_THDSTA[15:0] |0x00EF(5us)                     |0x0031(1.04us)     |0x0013(0.42us)
+|I2CM_TSUSTO[15:0] |0x00EF(5us)                     |0x0031(1.04us)     |0x0013(0.42us)
+|I2CM_TSUSTA[15:0] |0x0117(5.83us)                  |0x0031(1.04us)     |0x0013(0.42us)
+|I2CM_THIGH[15:0]  |0x00E5(4.79us)                  |0x0039(1.21us)     |0x0015(0.46us)
+|I2CM_THDDAT[15:0] |0x0013(0.42us)                  |0x0004(0.10us)     |0x0003(0.08us)
+|I2CM_TSUDAT[15:0] |0x00E5(4.79us)                  |0x0039(1.21us)     |0x0015(0.46us)
+|I2CM_TBUF[15:0]  |0x0117(5.83us)                   |0x0045(1.46us)     |0x001B(0.58us)
+|I2CM_FLTCYC[7:0] |0x2F(1000ns)                     |0x0E(312ns)        |0x05(125ns)
 |===
 
 .I2C Controller タイミングパラメータの設定例 (システムクロック 24 MHz)
 [cols=",,,",options="header",]
 |===
-|Parameter |Standard-mode(100Kb/s) |Fast-mode(400Kb/s) |Fast-mode
-Plus(1Mb/s)
-|I2CM_THDSTA[15:0] |0x0077(5us) |0x0018(1.04us) |0x0009(0.42us)
-
-|I2CM_TSUSTO[15:0] |0x0077(5us) |0x0018(1.04us) |0x0009(0.42us)
-
-|I2CM_TSUSTA[15:0] |0x008B(5.83us) |0x0018(1.04us) |0x0009(0.42us)
-
-|I2CM_THIGH[15:0] |0x0072(4.79us) |0x001B(1.17us) |0x0009(0.42us)
-
-|I2CM_THDDAT[15:0] |0x0009(0.42us) |0x0003(0.17us) |0x0003(0.17us)
-
-|I2CM_TSUDAT[15:0] |0x0072(4.79us) |0x001B(1.17us) |0x0009(0.42us)
-
-|I2CM_TBUF[15:0] |0x008B(5.83us) |0x0022(1.46us) |0x000D(0.58us)
-
-|I2CM_FLTCYC[7:0] |0x17(1000ns) |0x07(333ns) |0x02(125us)
+|Parameter         |Standard-mode(100Kb/s) |Fast-mode(400Kb/s) |Fast-mode Plus(1Mb/s)
+|I2CM_THDSTA[15:0] |0x0077(5us)            |0x0018(1.04us)     |0x0009(0.42us)
+|I2CM_TSUSTO[15:0] |0x0077(5us)            |0x0018(1.04us)     |0x0009(0.42us)
+|I2CM_TSUSTA[15:0] |0x008B(5.83us)         |0x0018(1.04us)     |0x0009(0.42us)
+|I2CM_THIGH[15:0]  |0x0072(4.79us)         |0x001B(1.17us)     |0x0009(0.42us)
+|I2CM_THDDAT[15:0] |0x0009(0.42us)         |0x0003(0.17us)     |0x0003(0.17us)
+|I2CM_TSUDAT[15:0] |0x0072(4.79us)         |0x001B(1.17us)     |0x0009(0.42us)
+|I2CM_TBUF[15:0]   |0x008B(5.83us)         |0x0022(1.46us)     |0x000D(0.58us)
+|I2CM_FLTCYC[7:0]  |0x17(1000ns)           |0x07(333ns)        |0x02(125us)
 |===
 
 制限事項：

--- a/modules/ROOT/pages/interrupt.adoc
+++ b/modules/ROOT/pages/interrupt.adoc
@@ -1,12 +1,9 @@
 == Interrupt
 
-SC-OBC-A1
-FPGAは、Cortex-M3に組み込まれる割り込みコントローラの外部割り込みを使用し、IPコアの割り込みをCPUに伝えます。
-Cortex-M3の 割り込みコントローラの仕様については、ARM Cortex-M3
-Technical Reference Manualを参照してください。
+SC-OBC-A1 FPGAは、Cortex-M3に組み込まれる割り込みコントローラの外部割り込みを使用し、IPコアの割り込みをCPUに伝えます。
+Cortex-M3の 割り込みコントローラの仕様については、ARM Cortex-M3 Technical Reference Manualを参照してください。
 
-IRQ Bit [31:16]は、Mission Bus
-Systemに割り当てられた割り込みビットです。
+IRQ Bit [31:16]は、Mission Bus Systemに割り当てられた割り込みビットです。
 ユーザーが設計した回路に応じて割り当てが決定します。
 
 以下に、SC-OBC-A1 FPGAの IPコアが出力する割り込みの割り当てを示します。
@@ -15,30 +12,30 @@ IRQ Bit [31:16]は、標準イメージにて実装されている割り込み�
 .SC-OBC-A1 FPGA割り込みリスト
 [cols=",,,",options="header",]
 |===
-|Exception No. |IRQ Bit |Interrupt |Type
-|16 |[0] |UART (Console) |Pulse
-|17 |[1] |HRMEM (High-reliability Memory) |Level
-|18 |[2] |QSPI Controller (Configuration Flash Memory) |Level
-|19 |[3] |QSPI Controller (Data Store Flash Memory) |Level
-|20 |[4] |QSPI Controller (FRAM) |Level
-|21 |[5] |CAN Controller |Level
-|22 |[6] |Reserved (OBC System Interrupt Area) |-
-|23 |[7] |External I2C Controller |Level
-|24 |[8] |System Monitor (Hardware Error) |Level
-|25 |[9] |System Monitor (Board Health Monitor) |Level
-|26 |[10] |General Purpose Timer (Global Timer) |Level
-|27 |[11] |General Purpose Timer (Software Interrupt Timer) |Level
-|28 - 31 |[15:12] |Reserved (OBC System Interrupt Area) |-
-|32 - 47 |[31:16] |UDL IP Interrupt Area |-
-|32 |[16] |UART 1 |Pulse
-|33 |[17] |UART 2 |Pulse
-|34 |[18] |UART 3 |Pulse
-|35 |[19] |UART 4 |Pulse
-|36 |[20] |UART 5 |Pulse
-|37 |[21] |UART 6 |Pulse
-|38 |[22] |I2C Controller 1 |Levle
-|39 |[23] |I2C Controller 2 |Level
-|40 |[24] |AMD QSPI Controller |Level
-|41 |[25] |AMD GPIO Controller |Level
-|47 - 42 |[31:26] |Reserved (UDL IP Interrupt Area) |-
+|Exception No. |IRQ Bit |Interrupt                                        |Type
+|16            |[0]     |UART (Console)                                   |Pulse
+|17            |[1]     |HRMEM (High-reliability Memory)                  |Level
+|18            |[2]     |QSPI Controller (Configuration Flash Memory)     |Level
+|19            |[3]     |QSPI Controller (Data Store Flash Memory)        |Level
+|20            |[4]     |QSPI Controller (FRAM)                           |Level
+|21            |[5]     |CAN Controller                                   |Level
+|22            |[6]     |Reserved (OBC System Interrupt Area)             |-
+|23            |[7]     |External I2C Controller                          |Level
+|24            |[8]     |System Monitor (Hardware Error)                  |Level
+|25            |[9]     |System Monitor (Board Health Monitor)            |Level
+|26            |[10]    |General Purpose Timer (Global Timer)             |Level
+|27            |[11]    |General Purpose Timer (Software Interrupt Timer) |Level
+|28 - 31       |[15:12] |Reserved (OBC System Interrupt Area)             |-
+|32 - 47       |[31:16] |UDL IP Interrupt Area                            |-
+|32            |[16]    |UART 1                                           |Pulse
+|33            |[17]    |UART 2                                           |Pulse
+|34            |[18]    |UART 3                                           |Pulse
+|35            |[19]    |UART 4                                           |Pulse
+|36            |[20]    |UART 5                                           |Pulse
+|37            |[21]    |UART 6                                           |Pulse
+|38            |[22]    |I2C Controller 1                                 |Levle
+|39            |[23]    |I2C Controller 2                                 |Level
+|40            |[24]    |AMD QSPI Controller                              |Level
+|41            |[25]    |AMD GPIO Controller                              |Level
+|47 - 42       |[31:26] |Reserved (UDL IP Interrupt Area)                 |-
 |===

--- a/modules/ROOT/pages/memory_map.adoc
+++ b/modules/ROOT/pages/memory_map.adoc
@@ -37,11 +37,9 @@ image::MemoryMap.svg[MemoryMap]
 |- ROM Table                                    |0xE00F_F000 - 0xE00F_FFFF |
 |===
 
-SC-OBC-A1 FPGAのメモリ空間において、0x50000000〜0x5FFFFFFFは Mission Bus
-Systemに予約された空間です。 このメモリ空間は、Mission Bus
-Systemの設計によって任意の構成に実装することができます。
-以下に示すメモリマップは、標準イメージに実装されている Mission Bus
-Systemのメモリマップです。
+SC-OBC-A1 FPGAのメモリ空間において、0x50000000〜0x5FFFFFFFは Mission Bus Systemに予約された空間です。
+このメモリ空間は、Mission Bus Systemの設計によって任意の構成に実装することができます。
+以下に示すメモリマップは、標準イメージに実装されている Mission Bus Systemのメモリマップです。
 
 .SC-OBC-A1 FPGA Mission Bus System Memory Map
 image::MissionBusMemoryMap.svg[MissionBusMemoryMap]
@@ -62,34 +60,22 @@ image::MissionBusMemoryMap.svg[MissionBusMemoryMap]
 |- AMD GPIO         |0x5009_0000 - 0x5009_FFFF |
 |===
 
-CPUが使用する メインメモリーは アドレス
-0x00000000にマッピングされています。 メインメモリーは、ITCM (Instruction
-Tightly Coupled Memory)と HRMEM (High Reliability
-Memory)を選択する事ができます。 ITCMと HRMEMの切り替えは Code Memory
-Select Registerの ITCMENビットによって行います。
+CPUが使用する メインメモリーは アドレス 0x00000000にマッピングされています。
+メインメモリーは、ITCM (Instruction Tightly Coupled Memory)と HRMEM (High Reliability Memory)を選択する事ができます。
+ITCMと HRMEMの切り替えは Code Memory Select Registerの ITCMENビットによって行います。
 
-ITCMは FPGAの Block RAMで構成されています。 このメモリは FPGAの
-Configurationデータ (Bit Streamデータ)にプログラムを格納する事で、FPGAの
-Configuration後 すぐに CPUが動作します。 HRMEMは On Boardの
-SRAMで構成されています。
+ITCMは FPGAの Block RAMで構成されています。 このメモリは FPGAの Configurationデータ (Bit Streamデータ)にプログラムを格納する事で、FPGAの Configuration後 すぐに CPUが動作します。
+HRMEMは On Boardの SRAMで構成されています。
 このメモリを使用する場合には、電源の投入後にデータを書き込んで使用する必要があります。
-HRMEMは IPコアの内部に
-SRAMのデータが放射線によって破壊された場合に訂正する仕組みを実装しているため、通常はこのメモリを使って動作します。
+HRMEMは IPコアの内部に SRAMのデータが放射線によって破壊された場合に訂正する仕組みを実装しているため、通常はこのメモリを使って動作します。
 
 .CPU Main Memory構成
 image::itcm_hrmem_select.png[itcm_hrmem_select]
 
-FPGAの Configuration後、アドレス 0x00000000に
-ITCMがマッピングされています。 ITCMには
-プログラムローダーを書き込んで使用します。 プログラムローダーは NOR
-Flash Memoryに書き込まれているプログラムを
-HRMEMに転送するために使用します。 HRMEMのアドレス
-0x60000000番地は、アドレス
-0x00000000番地のミラーとなっており、プログラムローダーによって
-0x60000000に書き込まれたデータは、メインメモリーを HRMEMに切り替えた時に
-0x00000000から読み出す事ができます。 プログラムローダーが
-HRMEMへのプログラムを書き込む最後の手順として、Code Memory Select
-Registerの ITCMENビットを 0に書き込みます。
-ITCMENビットの書き込みにより、メインメモリーを切り替えるとシステムにリセットがかかり、切り替えたメモリのアドレス
-0x00000000から書き込まれたデータで CPUが動作します。
+FPGAの Configuration後、アドレス 0x00000000に ITCMがマッピングされています。
+ITCMには プログラムローダーを書き込んで使用します。
+プログラムローダーは NOR Flash Memoryに書き込まれているプログラムを HRMEMに転送するために使用します。
+HRMEMのアドレス 0x60000000番地は、アドレス 0x00000000番地のミラーとなっており、プログラムローダーによって 0x60000000に書き込まれたデータは、メインメモリーを HRMEMに切り替えた時に 0x00000000から読み出す事ができます。
+プログラムローダーが HRMEMへのプログラムを書き込む最後の手順として、Code Memory Select Registerの ITCMENビットを 0に書き込みます。
+ITCMENビットの書き込みにより、メインメモリーを切り替えるとシステムにリセットがかかり、切り替えたメモリのアドレス 0x00000000から書き込まれたデータで CPUが動作します。
 

--- a/modules/ROOT/pages/pin_description.adoc
+++ b/modules/ROOT/pages/pin_description.adoc
@@ -1,50 +1,48 @@
 == User IO Pin Description
 
-SC-OBC-A1 FPGAの標準イメージにおいて、User
-IOに割り当てられている機能を以下に示します。
-これらの信号のアサインは、ユーザーの Mission Bus
-Systemの設計によって変わります。
+SC-OBC-A1 FPGAの標準イメージにおいて、User IOに割り当てられている機能を以下に示します。
+これらの信号のアサインは、ユーザーの Mission Bus Systemの設計によって変わります。
 
 .User IO Pin Description
 [cols=",,,",options="header",]
 |===
-|Pin No. |User IO |Direction |Description
-|7 |UIO1[0] |OUTPUT |UART 1 TX
-|8 |UIO1[1] |INPUT |UART 1 RX
-|9 |UIO1[2] |OUTPUT |UART 2 TX
-|10 |UIO1[3] |INPUT |UART 2 RX
-|11 |UIO1[4] |OUTPUT |UART 3 TX
-|12 |UIO1[5] |INPUT |UART 3 RX
-|13 |UIO1[6] |OUTPUT |UART 4 TX
-|14 |UIO1[7] |INPUT |UART 4 RX
-|16 |UIO1[8] |OUTPUT |UART 5 TX
-|17 |UIO1[9] |INPUT |UART 5 RX
-|18 |UIO1[10] |OUTPUT |UART 6 TX
-|19 |UIO1[11] |INPUT |UART 6 RX
-|20 |UIO1[12] |INOUT |I2C 1 SCL
-|21 |UIO1[13] |INOUT |I2C 1 SDA
-|22 |UIO1[14] |INOUT |I2C 2 SCL
-|23 |UIO1[15] |INOUT |I2C 2 SDA
-|74 |UIO2[0] |OUTPUT |SPI SCK
-|73 |UIO2[1] |OUTPUT |SPI MOSI
-|72 |UIO2[2] |INPUT |SPI MISO
-|71 |UIO2[3] |OUTPUT |SPI CS0
-|70 |UIO2[4] |OUTPUT |SPI CS1
-|69 |UIO2[5] |OUTPUT |SPI CS2
-|68 |UIO2[6] |INOUT |GPIO [6]
-|67 |UIO2[7] |INOUT |GPIO [7]
-|65 |UIO2[8] |INOUT |GPIO [8]
-|64 |UIO2[9] |INOUT |GPIO [9]
-|63 |UIO2[10] |INOUT |GPIO [10]
-|62 |UIO2[11] |INOUT |GPIO [11]
-|61 |UIO2[12] |INOUT |GPIO [12]
-|60 |UIO2[13] |INOUT |GPIO [13]
-|59 |UIO2[14] |INOUT |GPIO [14]
-|58 |UIO2[15] |INOUT |GPIO [15]
-|28 |UIO4[0] |INPUT |Reserved
-|47 |UIO4[1] |INPUT |SWCLK
-|46 |UIO4[2] |INPUT |SWDIO
-|45 |UIO4[3] |OUTPUT |UART Console TX
-|44 |UIO4[4] |INPUT |UART Console RX
-|43 |UIO4[5] |INPUT |Reserved
+|Pin No. |User IO  |Direction |Description
+|7       |UIO1[0]  |OUTPUT    |UART 1 TX
+|8       |UIO1[1]  |INPUT     |UART 1 RX
+|9       |UIO1[2]  |OUTPUT    |UART 2 TX
+|10      |UIO1[3]  |INPUT     |UART 2 RX
+|11      |UIO1[4]  |OUTPUT    |UART 3 TX
+|12      |UIO1[5]  |INPUT     |UART 3 RX
+|13      |UIO1[6]  |OUTPUT    |UART 4 TX
+|14      |UIO1[7]  |INPUT     |UART 4 RX
+|16      |UIO1[8]  |OUTPUT    |UART 5 TX
+|17      |UIO1[9]  |INPUT     |UART 5 RX
+|18      |UIO1[10] |OUTPUT    |UART 6 TX
+|19      |UIO1[11] |INPUT     |UART 6 RX
+|20      |UIO1[12] |INOUT     |I2C 1 SCL
+|21      |UIO1[13] |INOUT     |I2C 1 SDA
+|22      |UIO1[14] |INOUT     |I2C 2 SCL
+|23      |UIO1[15] |INOUT     |I2C 2 SDA
+|74      |UIO2[0]  |OUTPUT    |SPI SCK
+|73      |UIO2[1]  |OUTPUT    |SPI MOSI
+|72      |UIO2[2]  |INPUT     |SPI MISO
+|71      |UIO2[3]  |OUTPUT    |SPI CS0
+|70      |UIO2[4]  |OUTPUT    |SPI CS1
+|69      |UIO2[5]  |OUTPUT    |SPI CS2
+|68      |UIO2[6]  |INOUT     |GPIO [6]
+|67      |UIO2[7]  |INOUT     |GPIO [7]
+|65      |UIO2[8]  |INOUT     |GPIO [8]
+|64      |UIO2[9]  |INOUT     |GPIO [9]
+|63      |UIO2[10] |INOUT     |GPIO [10]
+|62      |UIO2[11] |INOUT     |GPIO [11]
+|61      |UIO2[12] |INOUT     |GPIO [12]
+|60      |UIO2[13] |INOUT     |GPIO [13]
+|59      |UIO2[14] |INOUT     |GPIO [14]
+|58      |UIO2[15] |INOUT     |GPIO [15]
+|28      |UIO4[0]  |INPUT     |Reserved
+|47      |UIO4[1]  |INPUT     |SWCLK
+|46      |UIO4[2]  |INPUT     |SWDIO
+|45      |UIO4[3]  |OUTPUT    |UART Console TX
+|44      |UIO4[4]  |INPUT     |UART Console RX
+|43      |UIO4[5]  |INPUT     |Reserved
 |===

--- a/modules/ROOT/pages/qspi_controller.adoc
+++ b/modules/ROOT/pages/qspi_controller.adoc
@@ -1,13 +1,9 @@
 == QSPI Controller
 
-QSPI Controllerは、SC
-OBCモジュールに搭載するメモリとSPIプロトコルによる通信を行うためのモジュールです。
-QSPI Controllerは、Single SPIモード, Dual SPIモード, Quad
-SPIモードに対応しており、メモリとの高速な通信を行う事ができます。
+QSPI Controllerは、SC OBCモジュールに搭載するメモリとSPIプロトコルによる通信を行うためのモジュールです。
+QSPI Controllerは、Single SPIモード, Dual SPIモード, Quad SPIモードに対応しており、メモリとの高速な通信を行う事ができます。
 
-SC OBCモジュールには、FPGAの Configurationデータを格納するためのNOR
-Flashメモリ (Configuration Flash Memory)と、運用データを格納するための
-NOR Flashメモリ (Data Store Flash Memory)及び FRAMが搭載されています。
+SC OBCモジュールには、FPGAの Configurationデータを格納するためのNOR Flashメモリ (Configuration Flash Memory)と、運用データを格納するための NOR Flashメモリ (Data Store Flash Memory)及び FRAMが搭載されています。
 これに対し QSPI Controllerは 3個搭載されています。
 また、各メモリは冗長化の目的で 2個ずつ搭載されています。
 
@@ -17,19 +13,14 @@ QSPI Controllerとメモリの構成を以下に示します。
 image::qspi_controller_structure.png[qspi_controller_structure]
 
 SC OBCモジュールに実装される メモリの型番は以下の通りです。
-各メモリの仕様については、ベンダーからリリースされている
-Datasheetを参照してください。
+各メモリの仕様については、ベンダーからリリースされている Datasheetを参照してください。
 
 [cols=",,,,",options="header",]
 |===
-|Memory |用途 |Vendor |Part Number |SC OBC搭載数
-|Configuration Flash Memory |FPGA Configurationデータの格納 |infineon
-(旧Cypress) |S25FL256L |2 個
-
-|Data Store Flash Memory |運用データの格納 |infineon (旧Cypress)
-|S25FL256L |2 個
-
-|FRAM |運用データの格納 |infineon (旧Cypress) |CY15B104QSN |2 個
+|Memory                     |用途                           |Vendor               |Part Number |SC OBC搭載数
+|Configuration Flash Memory |FPGA Configurationデータの格納 |infineon (旧Cypress) |S25FL256L   |2 個
+|Data Store Flash Memory    |運用データの格納               |infineon (旧Cypress) |S25FL256L   |2 個
+|FRAM                       |運用データの格納               |infineon (旧Cypress) |CY15B104QSN |2 個
 |===
 
 QSPI Controllerは、各メモリにアクセスするため 3個搭載されています。
@@ -38,10 +29,10 @@ QSPI Controllerは、各メモリにアクセスするため 3個搭載されて
 .QSPI Controller アドレスの割り当て
 [cols=",",options="header",]
 |===
-|Target |Base Address
+|Target                     |Base Address
 |Configuration Flash Memory |0x4000_0000
-|Data Store Memory |0x4010_0000
-|FRAM |0x4020_0000
+|Data Store Memory          |0x4010_0000
+|FRAM                       |0x4020_0000
 |===
 
 === レジスタ詳細
@@ -49,7 +40,7 @@ QSPI Controllerは、各メモリにアクセスするため 3個搭載されて
 QSPI Controllerには以下のレジスタが実装されています。
 
 .QSPI Controller Register メモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset |Symbol      |Register |Initial
 |0x0000 |QSPI_ACR    |QSPI Access Control Register               |0x00000000
@@ -68,43 +59,33 @@ QSPI Controllerには以下のレジスタが実装されています。
 
 ==== QSPI Access Control Register (Offset 0x0000)
 
-QSPI Access Control Registerは、SPIアクセスにおける
-SS信号、I/Oモードを制御するためのレジスタです。
+QSPI Access Control Registerは、SPIアクセスにおける SS信号、I/Oモードを制御するためのレジスタです。
 
-Data Store Memoryと FRAMの制御を行う QSPI
-Controllerは、2つのメモリへのアクセスの切り替えを
-SPISSCTLビットで行います。
-メモリへのアクセスを開始するときは、SPISSCTLを 0b01または
-0b10に設定し、アクセス対象の SS信号をアサートします。 SPISSCTLを
-0b11に設定することは禁止です。
+Data Store Memoryと FRAMの制御を行う QSPI Controllerは、2つのメモリへのアクセスの切り替えを SPISSCTLビットで行います。
+メモリへのアクセスを開始するときは、SPISSCTLを 0b01または 0b10に設定し、アクセス対象の SS信号をアサートします。
+SPISSCTLを 0b11に設定することは禁止です。
 
-Configuration Flash Memoryを制御する QSPI Controllerは、SS信号が
-1本しか接続されておらず、OBCモジュールの基板上でセレクトされています。
-そのため、Configuration Flash
-Memoryへアクセスを行う場合は、アクセスするメモリに関わらず SPISSCTLを
-0b01にセットします。 Configuration Flash Memoryのメモリ選択は、System
-Registerの Configuration Flash Memory
-Registerの設定により行うことができます。 詳細は、System
-Registerの「Configuration Flash Memory
-Register」の章を参照してください。
+Configuration Flash Memoryを制御する QSPI Controllerは、SS信号が 1本しか接続されておらず、OBCモジュールの基板上でセレクトされています。
+そのため、Configuration Flash Memoryへアクセスを行う場合は、アクセスするメモリに関わらず SPISSCTLを 0b01にセットします。
+Configuration Flash Memoryのメモリ選択は、System Registerの Configuration Flash Memory Registerの設定により行うことができます。
+詳細は、System Registerの「Configuration Flash Memory Register」の章を参照してください。
 
 .QSPI Access Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:18 |- |Reserved |Reserved |-
-
-|17:16 |SPIIOMODE |SPI I/O Mode
-|SPIアクセスにおけるI/Oモードを設定します。 2b00: Standard(Single)-IO
-SPIモード 2b01: Dual-IO SPIモード 2b10: Quad-IO SPIモード 2b11: 設定禁止
-|R/W
-
-|15:2 |- |Reserved |Reserved |-
-
-|1:0 |SPISSCTL |SPI CS Control |Chip
-Select信号の制御をするためのフィールドです。0b00: CS信号をネゲート 0b01:
-メモリ 1の CS信号をアサート 0b10: メモリ 2の CS信号をアサート 0b11: 禁止
-|R/W
+|bit   |Symbol    |Field          |Description |R/W
+|31:18 |-         |Reserved       |Reserved    |-
+|17:16 |SPIIOMODE |SPI I/O Mode   |SPIアクセスにおけるI/Oモードを設定します。 +
+                               2b00: Standard(Single)-IO SPIモード +
+                               2b01: Dual-IO SPIモード +
+                               2b10: Quad-IO SPIモード +
+                               2b11: 設定禁止                                  |R/W
+|15:2  |-         |Reserved       |Reserved                                        |-
+|1:0   |SPISSCTL  |SPI CS Control |Chip Select信号の制御をするためのフィールドです。 +
+                               0b00: CS信号をネゲート +
+                               0b01: メモリ 1の CS信号をアサート +
+                               0b10: メモリ 2の CS信号をアサート +
+                               0b11: 禁止                                      |R/W
 |===
 
 ==== QSPI TX Data Register (Offset 0x0004)
@@ -114,80 +95,60 @@ Registerは、SPIデバイスにデータを送信するためのレジスタで
 
 SPIデバイスへのデータ送信は TX FIFOを介し行います。
 
-SPIデバイスにデータを送信する場合、QSPI TX Data Registerの
-SPITXDATAフィールドに書き込みを行います。
-このレジスタにデータを書き込むと、書き込みデータは TX
-FIFOに格納されます。 TX FIFOは送信データを最大16 Byte格納できます。 TX
-FIFOに格納されたデータは、書き込まれた順番ですぐに
-SPIデバイスに送信されます。
+SPIデバイスにデータを送信する場合、QSPI TX Data Registerの SPITXDATAフィールドに書き込みを行います。
+このレジスタにデータを書き込むと、書き込みデータは TX FIFOに格納されます。 TX FIFOは送信データを最大16 Byte格納できます。
+TX FIFOに格納されたデータは、書き込まれた順番ですぐに SPIデバイスに送信されます。
 
 SPIデバイスが要求するダミーサイクルは、このレジスタに書き込みを行うことによって、SPIクロックを出力させ生成します。
 
 .QSPI TX Data Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |SPITXDATA |SPI Tx Data |TX
-FIFOに格納する送信データを書き込みます。このレジスタに書き込んだデータはTX
-FIFOに格納され、書き込まれた順番ですぐに送信されます。 |WO
+|bit  |Symbol    |Field       |Description                                                                                                                          |R/W
+|31:8 |-         |Reserved    |Reserved                                                                                                                             |-
+|7:0  |SPITXDATA |SPI Tx Data |TX FIFOに格納する送信データを書き込みます。このレジスタに書き込んだデータはTX FIFOに格納され、書き込まれた順番ですぐに送信されます。 |WO
 |===
 
 ==== QSPI RX Data Register (Offset 0x0008)
 
-QSPI RX Data Registerは、SPIデバイスからのデータ受信制御と、RX
-FIFOからの受信データの読み出しを行うためのレジスタです。
+QSPI RX Data Registerは、SPIデバイスからのデータ受信制御と、RX FIFOからの受信データの読み出しを行うためのレジスタです。
 
 SPIデバイスからのデータ受信は RX FIFOを介して行います。
 
-SPIデバイスからデータを受信する場合、QSPI RX Data Registerの
-SPIRXDATAフィールドに書き込みアクセスを行います。
+SPIデバイスからデータを受信する場合、QSPI RX Data Registerの SPIRXDATAフィールドに書き込みアクセスを行います。
 このレジスタに書き込む値は何も影響しません。
-SPIRXDATAビットの書き込みが行われると、SPIデバイスに対し
-SPIクロックが送信され、SPIデバイスはそのクロックに同期しデータを出力します。
-SPIデバイスの出力データは、RX FIFOに格納されます。 RX FIFOは 最大 16
-Byteのデータを格納する事ができます。
+SPIRXDATAビットの書き込みが行われると、SPIデバイスに対し SPIクロックが送信され、SPIデバイスはそのクロックに同期しデータを出力します。
+SPIデバイスの出力データは、RX FIFOに格納されます。
+RX FIFOは 最大 16 Byteのデータを格納する事ができます。
 
-RX FIFOに格納されたデータを読み出す場合、QSPI RX Data Registerの
-SPIRXDATAフィールドに読み出しアクセスを行います。 データは
-SPIデバイスから出力された順に読み出されます。
+RX FIFOに格納されたデータを読み出す場合、QSPI RX Data Registerの SPIRXDATAフィールドに読み出しアクセスを行います。
+データは SPIデバイスから出力された順に読み出されます。
 
-QSPI Data Capture Mode Setting Registerの DTCAPTビットが"1"
-にセットされている時、SPIRXDATAフィールドの書き込み時だけではなく、QSPI
-TX Data Registerの書き込み時も、RX FIFOにデータが格納されます。 この時
-RX FIFOに格納されているデータは SPITXDATAに書き込んだデータ
-(SPIに出力されているデータ)となります。
+QSPI Data Capture Mode Setting Registerの DTCAPTビットが"1" にセットされている時、SPIRXDATAフィールドの書き込み時だけではなく、QSPI TX Data Registerの書き込み時も、RX FIFOにデータが格納されます。
+この時 RX FIFOに格納されているデータは SPITXDATAに書き込んだデータ (SPIに出力されているデータ)となります。
 
 .QSPI RX Data Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |SPIRXDATA |SPI Rx Data
-|このレジスタへの書き込み時は、SPIクロックを送信しデバイスからのデータ受信を行います。このレジスタの読み出し時は、RX
-FIFOに格納されたデータが古い順に読み出されます。 |R/W
+|bit  |Symbol    |Field       |Description                                                                                                                                                          |R/W
+|31:8 |-         |Reserved    |Reserved                                                                                                                                                             |-
+|7:0  |SPIRXDATA |SPI Rx Data |このレジスタへの書き込み時は、SPIクロックを送信しデバイスからのデータ受信を行います。このレジスタの読み出し時は、RX FIFOに格納されたデータが古い順に読み出されます。 |R/W
 |===
 
 ==== QSPI Access Status Register (Offset 0x000C)
 
-QSPI Access Status Registerは、QSPI
-Controllerの実行ステータスを確認するためのレジスタです。
+QSPI Access Status Registerは、QSPI Controllerの実行ステータスを確認するためのレジスタです。
 
-QSPI Controllerは、QSPI TX Data Registerへの書き込み、QSPI Rx Data
-Registerへの書き込み、QSPI Access Control Registerの SPI SS
-Controlレジスタの書き込み時に Busy状態となり、SPIが未使用状態になると
-Idle状態に戻ります。
+QSPI Controllerは、QSPI TX Data Registerへの書き込み、QSPI Rx Data Registerへの書き込み、QSPI Access Control Registerの SPI SS Controlレジスタの書き込み時に Busy状態となり、SPIが未使用状態になると Idle状態に戻ります。
 
 .QSPI Access Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |SPIBUSY |SPI Status Busy |QSPI
-Controllerの実行ステータスを表示します。 0: Idle状態 1: Busy状態 |RO
+|bit  |Symbol  |Field           |Description                                  |R/W
+|31:1 |-       |Reserved        |Reserved                                     |-
+|0    |SPIBUSY |SPI Status Busy |QSPI Controllerの実行ステータスを表示します。 +
+0: Idle状態 +
+1: Busy状態 |RO
 |===
 
 ==== QSPI FIFO Status Register (Offset 0x0010)
@@ -197,132 +158,71 @@ QSPI FIFO Status Registerは、TX FIFO/RX FIFOの状態を示すレジスタで�
 .QSPI FIFO Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |- |Reserved |Reserved |-
-
-|20:16 |TXFIFOCAP |TX FIFO Capacity |TX
-FIFOに格納されているデータ量を示すフィールドです。 |RO
-
-|15:5 |- |Reserved |Reserved |-
-
-|4:0 |RXFIFOCAP |RX FIFO Capacity |RX
-FIFOに格納されているデータ量を示すフィールドです。 |RO
+|bit   |Symbol    |Field            |Description                                           |R/W
+|31:21 |-         |Reserved         |Reserved                                              |-
+|20:16 |TXFIFOCAP |TX FIFO Capacity |TX FIFOに格納されているデータ量を示すフィールドです。 |RO
+|15:5  |-         |Reserved         |Reserved                                              |-
+|4:0   |RXFIFOCAP |RX FIFO Capacity |RX FIFOに格納されているデータ量を示すフィールドです。 |RO
 |===
 
 ==== QSPI FIFO Reset Register (Offset 0x0014)
 
-QSPI FIFO Reset Registerは、TX FIFO/RX
-FIFOのリセット制御(データ消去)を行うためのレジスタです。
+QSPI FIFO Reset Registerは、TX FIFO/RX FIFOのリセット制御(データ消去)を行うためのレジスタです。
 何らかの理由によりFIFOのクリアを行いたい場合にこのレジスタを使用します。
 
 .QSPI FIFO Reset Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |TXFIFORST |TX FIFO Reset |本ビットに1をセットすると、TX
-FIFOがクリアされデータが消去されます。 |WO
-
-|15:1 |- |Reserved |Reserved |-
-
-|0 |RXFIFORST |RX FIFO Reset |本ビットに1をセットすると、RX
-FIFOがクリアされデータが消去されます。 |WO
+|bit   |Symbol    |Field         |Description                                                          |R/W
+|31:17 |-         |Reserved      |Reserved                                                             |-
+|16    |TXFIFORST |TX FIFO Reset |本ビットに1をセットすると、TX FIFOがクリアされデータが消去されます。 |WO
+|15:1  |-         |Reserved      |Reserved                                                             |-
+|0     |RXFIFORST |RX FIFO Reset |本ビットに1をセットすると、RX FIFOがクリアされデータが消去されます。 |WO
 |===
 
 ==== QSPI Interrupt Status Register (Offset: 0x0020)
 
-QSPI Interrupt Status Registerは、QSPI
-Controllerの割り込みステータスレジスタです。 全ての割り込みビットは
-”1"をセットするとクリアする事ができます。
+QSPI Interrupt Status Registerは、QSPI Controllerの割り込みステータスレジスタです。
+全ての割り込みビットは ”1"をセットするとクリアする事ができます。
 
 .QSPI Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:27 |- |Reserved |Reserved |-
-
-|26 |TXFIFOUTH |TX FIFO Under Threshold |TX
-FIFOに格納されたデータが設定した閾値を下回った事を示すビットです。TX
-FIFOに格納されるデータ量が QSPI FIFO Threshold Level Setting Registerの
-TXFIFOUTHLフィールドよりも少なくなった場合に本ビットがセットされます。
-|R/WC
-
-|25 |TXFIFOOVF |TX FIFO Overflow |TX FIFOの
-Overflowが発生したことを示すビットです。TX FIFOが Fullの状態で QSPI TX
-Data Registerに書き込みを行うと本ビットがセットされます。 |R/WC
-
-|24 |TXFIFOUDF |TX FIFO Underflow |TX FIFOの
-Underflowが発生したことを示すビットです。この割り込みは通常の状態で発生する事はありません。この割り込みが発生した場合は、本モジュールをリセットしてください。
-|R/WC
-
-|23:19 |- |Reserved |Reserved |-
-
-|18 |RXFIFOOTH |RX FIFO Over Threshold |RX
-FIFOに格納されたデータが設定した閾値を上回った事を示すビットです。RX
-FIFOに格納されるデータ量が QSPI FIFO Threshold Level Setting Registerの
-RXFIFOOTHLフィールドよりも多くなった場合に本ビットがセットされます。
-|R/WC
-
-|17 |RXFIFOOVF |RX FIFO Overflow |RX FIFOの
-Overflowが発生したことを示すビットです。RX FIFOが
-Fullの状態でデータ受信を行うと本ビットがセットされます。 |R/WC
-
-|16 |RXFIFOUDF |RX FIFO Underflow |RX FIFOの
-Underflowが発生したことを示すビットです。RX FIFOが Emptyの状態で QSPI RX
-Data Registerの読み出しを行うと本ビットがセットされます。 |R/WC
-
-|15:1 |- |Reserved |Reserved |-
-
-|0 |SPICTRLDN |SPI Control Done
-|SPI制御が完了した事を示すビットです。QSPI
-Controllerの実行ステータス(QSPI Access Status Register: SPI Status
-Busyビット)が BusyからIdleに変化した時、本ビットが 1にセットされます。
-|R/WC
+|bit   |Symbol    |Field                   |Description                                                                                                                                      |R/W
+|31:27 |-         |Reserved                |Reserved                                                                                                                                         |-
+|26    |TXFIFOUTH |TX FIFO Under Threshold |TX FIFOに格納されたデータが設定した閾値を下回った事を示すビットです。
+                                       TX FIFOに格納されるデータ量が QSPI FIFO Threshold Level Setting Registerの TXFIFOUTHLフィールドよりも少なくなった場合に本ビットがセットされます。|R/WC
+|25    |TXFIFOOVF |TX FIFO Overflow        |TX FIFOの Overflowが発生したことを示すビットです。TX FIFOが Fullの状態で QSPI TX Data Registerに書き込みを行うと本ビットがセットされます。       |R/WC
+|24    |TXFIFOUDF |TX FIFO Underflow       |TX FIFOの Underflowが発生したことを示すビットです。
+                                       この割り込みは通常の状態で発生する事はありません。この割り込みが発生した場合は、本モジュールをリセットしてください。                             |R/WC
+|23:19 |-         |Reserved                |Reserved                                                                                                                                         |-
+|18    |RXFIFOOTH |RX FIFO Over Threshold  |RX FIFOに格納されたデータが設定した閾値を上回った事を示すビットです。
+                                       RX FIFOに格納されるデータ量が QSPI FIFO Threshold Level Setting Registerの RXFIFOOTHLフィールドよりも多くなった場合に本ビットがセットされます。  |R/WC
+|17    |RXFIFOOVF |RX FIFO Overflow        |RX FIFOの Overflowが発生したことを示すビットです。RX FIFOが Fullの状態でデータ受信を行うと本ビットがセットされます。 |R/WC
+|16    |RXFIFOUDF |RX FIFO Underflow       |RX FIFOの Underflowが発生したことを示すビットです。RX FIFOが Emptyの状態で QSPI RX Data Registerの読み出しを行うと本ビットがセットされます。     |R/WC
+|15:1  |-         |Reserved                |Reserved                                                                                                                                         |-
+|0     |SPICTRLDN |SPI Control Done        |SPI制御が完了した事を示すビットです。
+                                       QSPI Controllerの実行ステータス(QSPI Access Status Register: SPI Status Busyビット)が BusyからIdleに変化した時、本ビットが 1にセットされます。   |R/WC
 |===
 
 ==== QSPI Interrupt Enable Register (Offset: 0x0024)
 
-QSPI Interrupt Enable Registerは、QSPI
-Controllerの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
+QSPI Interrupt Enable Registerは、QSPI Controllerの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
 
 .QSPI Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:27 |- |Reserved |Reserved |-
-
-|26 |TXFIFOUTHEMB |TX FIFO Under Threshold Enable
-|TXFIFOUTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|25 |TXFIFOOVFEMB |TX FIFO Overflow Enable
-|TXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|24 |TXFIFOUDFEMB |TX FIFO Underflow Enable
-|TXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|23:19 |- |Reserved |Reserved |-
-
-|18 |RXFIFOOTHEMB |RX FIFO Over Threshold Enable
-|RXFIFOOTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|17 |RXFIFOOVFEMB |RX FIFO Overflow Enable
-|RXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|16 |RXFIFOUDFEMB |RX FIFO Underflow Enable
-|RXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|15:1 |- |Reserved |Reserved |-
-
-|0 |SPIBUSYDNEMB |SPI Status Busy Done Enable
-|SPIBUSYDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
+|bit   |Symbol       |Field                          |Description                                                                  |R/W
+|31:27 |-            |Reserved                       |Reserved                                                                     |-
+|26    |TXFIFOUTHEMB |TX FIFO Under Threshold Enable |TXFIFOUTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|25    |TXFIFOOVFEMB |TX FIFO Overflow Enable        |TXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|24    |TXFIFOUDFEMB |TX FIFO Underflow Enable       |TXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|23:19 |-            |Reserved                       |Reserved                                                                     |-
+|18    |RXFIFOOTHEMB |RX FIFO Over Threshold Enable  |RXFIFOOTHイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|17    |RXFIFOOVFEMB |RX FIFO Overflow Enable        |RXFIFOOVFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|16    |RXFIFOUDFEMB |RX FIFO Underflow Enable       |RXFIFOUDFイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|15:1  |-            |Reserved                       |Reserved |-
+|0     |SPIBUSYDNEMB |SPI Status Busy Done Enable    |SPIBUSYDNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
 |===
 
 ==== QSPI Clock Control Register (Offset 0x0030)
@@ -333,29 +233,21 @@ Registerは、SPIクロックの周波数、極性、位相設定を制御する
 .QSPI Clock Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |- |Reserved |Reserved |-
-
-|20 |SCKPOL |SPI Clock Polarity
-|SPIクロックのクロック極性(CPOL)を設定します。0: Idle時のクロックを Low
-Levelとする 1: Idle時のクロックを High Levelとする |R/W
-
-|19:17 |- |Reserved |Reserved |-
-
-|16 |SCKPHA |SPI Clock Phase
-|SPIクロックのクロック位相(CPHA)を設定します。0: Data sampling: Rise
-Edge / Data Shift: Fall Edge 1: Data sampling: Fall Edge / Data Shift:
-Rise Edge |R/W
-
-|15:12 |- |Reserved |Reserved |-
-
-|11:0 |SCKDIV |SPI Clock Divide
-|システムクロックに対するSPIクロックの分周数を設定します。本フィールドに0(最小値)をセットした場合、SPI
-Clockはシステムクロックを2分周した周波数で動作します。 |R/W
+|bit   |Symbol |Field              |Description                                                                                         |R/W
+|31:21 |-      |Reserved           |Reserved                                                                                            |-
+|20    |SCKPOL |SPI Clock Polarity |SPIクロックのクロック極性(CPOL)を設定します。 +
+                                0: Idle時のクロックを Low Levelとする +
+                                1: Idle時のクロックを High Levelとする                                                              |R/W
+|19:17 |-      |Reserved           |Reserved |-
+|16    |SCKPHA |SPI Clock Phase    |SPIクロックのクロック位相(CPHA)を設定します。 +
+                                0: Data sampling: Rise Edge / Data Shift: Fall Edge +
+                                1: Data sampling: Fall Edge / Data Shift: Rise Edge                                                 |R/W
+|15:12 |-      |Reserved           |Reserved                                                                                                                                                     |-
+|11:0  |SCKDIV |SPI Clock Divide   |システムクロックに対するSPIクロックの分周数を設定します。
+                                本フィールドに0(最小値)をセットした場合、SPI Clockはシステムクロックを2分周した周波数で動作します。 |R/W
 |===
 
-SPIクロックの周波数(fSCLK)は、システムクロック(fSYS)と
-SCKDIVの設定により以下のように計算されます。
+SPIクロックの周波数(fSCLK)は、システムクロック(fSYS)と SCKDIVの設定により以下のように計算されます。
 
 [stem]
 ++++
@@ -364,49 +256,34 @@ fSCLK[MHz] = \frac{fSYS[MHz]}{2(SCKDIV+1)}
 
 ==== QSPI Data Capture Mode Setting Register (Offset 0x0034)
 
-QSPI Data Capture Mode Setting Registerは、RX
-FIFOにデータを取り込む条件を設定するためのレジスタです。
-このレジスタをセットすることで、QSPI RX Data
-Registerへの書き込みアクセスを行った時だけではなく、QSPI TX Data
-Registerへの書き込みを行った時もデータの取り込みを行う事ができます。
-これにより
-SPIデバイスへの「送信フェーズ」「ダミーフェーズ」を含めた全てのフェーズのデータを取り込むことができます。
+QSPI Data Capture Mode Setting Registerは、RX FIFOにデータを取り込む条件を設定するためのレジスタです。
+このレジスタをセットすることで、QSPI RX Data Registerへの書き込みアクセスを行った時だけではなく、QSPI TX Data Registerへの書き込みを行った時もデータの取り込みを行う事ができます。
+これにより SPIデバイスへの「送信フェーズ」「ダミーフェーズ」を含めた全てのフェーズのデータを取り込むことができます。
 
 .QSPI Data Capture Mode Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:1 |- |Reserved |Reserved |-
-
-|0 |DTCAPT |Data Capture |RX FIFOにデータを取り込む条件を設定します。0:
-QSPI RX Data Registerの書き込み時のみ 1: QSPI TX Data Registerと QSPI RX
-Data Registerの両方の書き込み時 |R/W
+|bit  |Symbol |Field        |Description                                                        |R/W
+|31:1 |-      |Reserved     |Reserved                                                           |-
+|0    |DTCAPT |Data Capture |RX FIFOにデータを取り込む条件を設定します。 +
+                          0: QSPI RX Data Registerの書き込み時のみ +
+                          1: QSPI TX Data Registerと QSPI RX Data Registerの両方の書き込み時 |R/W
 |===
 
 ==== QSPI FIFO Threshold Level Setting Register (Offset 0x0038)
 
-QSPI FIFO Threshold Level Setting Registerは、TX FIFO/RX
-FIFOのデータ量に応じた割り込み出力を行うための設定レジスタです。
+QSPI FIFO Threshold Level Setting Registerは、TX FIFO/RX FIFOのデータ量に応じた割り込み出力を行うための設定レジスタです。
 
 .QSPI FIFO Threshold Level Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:21 |- |Reserved |Reserved |-
-
-|20:16 |TXFIFOUTHL |TX FIFO Under Threshold Level
-|TXFIFOUTH割り込みを発生させる TX
-FIFOのデータ格納量の閾値を設定するためのフィールドです。本フィールドに
-0または最大値を設定した場合
-TXFIFOUTHは無効となり、割り込みは発生しません。 |R/W
-
-|15:5 |- |Reserved |Reserved |-
-
-|4:0 |RXFIFOOTHL |RX FIFO Over Threshold Level
-|RXFIFOOTH割り込みを発生させる RX
-FIFOのデータ格納料の閾値を設定するためのフィールドです。本フィールドに
-0または最大値を設定した場合
-RXFIFOOTHは無効となり、割り込みは発生しません。 |R/W
+|bit   |Symbol     |Field                         |Description                                                                                |R/W
+|31:21 |-          |Reserved                      |Reserved                                                                                   |-
+|20:16 |TXFIFOUTHL |TX FIFO Under Threshold Level |TXFIFOUTH割り込みを発生させる TX FIFOのデータ格納量の閾値を設定するためのフィールドです。
+                                             本フィールドに 0または最大値を設定した場合 TXFIFOUTHは無効となり、割り込みは発生しません。 |R/W
+|15:5  |-          |Reserved                      |Reserved                                                                                   |-
+|4:0   |RXFIFOOTHL |RX FIFO Over Threshold Level  |RXFIFOOTH割り込みを発生させる RX FIFOのデータ格納料の閾値を設定するためのフィールドです。
+                                             本フィールドに 0または最大値を設定した場合 RXFIFOOTHは無効となり、割り込みは発生しません。 |R/W
 |===
 
 ==== QSPI Controller IP Version Register (Offset: 0xF000)
@@ -416,124 +293,84 @@ QSPI Controller IPコアバージョンの管理レジスタです。
 .QSPI Controller IP Version Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |MAJVER |QSPI Controller IP Major Version |QSPI
-ControllerコアのMajor Versionです。 |RO
-
-|23:16 |MINVER |QSPI Controller IP Minor Version |QSPI
-ControllerコアのMinor Versionです。 |RO
-
-|15:0 |PATVER |QSPI Controller IP Patch Version |QSPI
-ControllerコアのPatch Versionです。 |RO
+|bit   |Symbol |Field                            |Description                              |R/W
+|31:24 |MAJVER |QSPI Controller IP Major Version |QSPI ControllerコアのMajor Versionです。 |RO
+|23:16 |MINVER |QSPI Controller IP Minor Version |QSPI ControllerコアのMinor Versionです。 |RO
+|15:0  |PATVER |QSPI Controller IP Patch Version |QSPI ControllerコアのPatch Versionです。 |RO
 |===
 
 === QSPIアクセス手順
 
-この章では、Infineon製Flash Memory 「S25FL256L」を例に、QSPI
-Controllerによる Flashメモリの書き込み,
-読み出しを行うための手順を説明します。
+この章では、Infineon製Flash Memory 「S25FL256L」を例に、QSPI Controllerによる Flashメモリの書き込み、読み出しを行うための手順を説明します。
 
 ==== データ書き込み操作手順例
 
-本章では、Quad Page ProgramコマンドによるFlash
-Memoryへのデータ書き込みの手順を説明します。
+本章では、Quad Page ProgramコマンドによるFlash Memoryへのデータ書き込みの手順を説明します。
 CPOL=0、CPHA=0に設定した時のSPI Interface波形と手順を以下に示します。
 
 .Quad Page Program アクセス波形
 image::quad_page_program_acc_seq.png[quad_page_program_acc_seq]
 
 以下の手順は、メモリ 1にアクセスする場合のレジスタ設定例を示しています。
-Configuration Flash Memoryを除き、メモリ 2にアクセスする場合は、QSPI
-Access Control Registerの SPISSCTLを 0x01から 0x02に置き換えて下さい。
+Configuration Flash Memoryを除き、メモリ 2にアクセスする場合は、QSPI Access Control Registerの SPISSCTLを 0x01から 0x02に置き換えて下さい。
 
 A::
-  QSPI Access Control Registerを設定します。 SPI I/O Modeは
-  Standard(Single)-IO SPIモード、SPI SS
-  Controlは"1"とするため、0x00000001を書き込みます。
+  QSPI Access Control Registerを設定します。
+  SPI I/O Modeは Standard(Single)-IO SPIモード、SPI SS Controlは"1"とするため、0x00000001を書き込みます。
   書き込み後、SPI_CS信号がアクティブ状態(Low level)に変化します。
 B::
-  QSPI TX Data Registerに 1 ByteのInstruction(Quad Page Program: 0x32)と
-  3 Byteの Addressを書き込みます。 QSPI TX Data
-  Registerに書き込まれたデータからSPIデバイスに順次送信されます。
+  QSPI TX Data Registerに 1 ByteのInstruction(Quad Page Program: 0x32)と 3 Byteの Addressを書き込みます。 QSPI TX Data Registerに書き込まれたデータからSPIデバイスに順次送信されます。
 C::
-  Bで書き込んだ全てのデータの送信完了後に、QSPI Access Control
-  Registerに0x00020001を書き込み、SPI I/O ModeをQuad-IO
-  SPIモードに変更します。
+  Bで書き込んだ全てのデータの送信完了後に、QSPI Access Control Registerに0x00020001を書き込み、SPI I/O ModeをQuad-IO SPIモードに変更します。
 D::
-  Flash MemoryへのWriteデータをQSPI TX Data
-  Registerに書き込み、データ送信を行います。TX
-  FIFOは送信するデータを最大16Byteまで格納することができます。 TX
-  FIFOの容量を超えるサイズのデータを送信する場合は、TX FIFOが
-  OverflowしないようQSPI TX Data
-  Registerへの書き込み間隔を調整する必要があります。
-  TX_FIFOのデータ格納量のステータスは、QSPI FIFO Status
-  RegisterやTX_FIFO関連の割り込み要因により確認することができます。
+  Flash MemoryへのWriteデータをQSPI TX Data Registerに書き込み、データ送信を行います。
+  TX FIFOは送信するデータを最大16Byteまで格納することができます。
+  TX FIFOの容量を超えるサイズのデータを送信する場合は、TX FIFOが OverflowしないようQSPI TX Data Registerへの書き込み間隔を調整する必要があります。
+  TX_FIFOのデータ格納量のステータスは、QSPI FIFO Status RegisterやTX_FIFO関連の割り込み要因により確認することができます。
 E::
-  Dで書き込んだ全てのデータの送信完了後に、QSPI Access Control
-  Registerに0x0000_0000を書き込みSPICS信号をインアクティブ状態(High
-  level)に変化させ、SPIアクセスを終了します。
+  Dで書き込んだ全てのデータの送信完了後に、QSPI Access Control Registerに0x0000_0000を書き込みSPICS信号をインアクティブ状態(High level)に変化させ、SPIアクセスを終了します。
 
-CからD時の遷移を除いた全てのフェーズの切り替わりには、QSPI
-Controllerの実行ステータスを確認し、必ずIdle状態となってから次の操作を実行する必要があります。
+CからD時の遷移を除いた全てのフェーズの切り替わりには、QSPI Controllerの実行ステータスを確認し、必ずIdle状態となってから次の操作を実行する必要があります。
 実行ステータスの確認方法は以下の2通りがあります。
 
 * QSPI Access Status Registerの監視
 * SPICTRLDN割り込みの検出
 
-QSPI
-Controllerの実行ステータスがBusyの状態で次の操作が実行された場合、SPIアクセスは不適切なフォーマットで転送される可能性があります。
+QSPI Controllerの実行ステータスがBusyの状態で次の操作が実行された場合、SPIアクセスは不適切なフォーマットで転送される可能性があります。
 
 ==== データ読み出し操作手順例
 
-本章では、Quad I/O ReadコマンドによるFlash
-Memoryからのデータ読み出しの手順を説明します。
+本章では、Quad I/O ReadコマンドによるFlash Memoryからのデータ読み出しの手順を説明します。
 CPOL=0、CPHA=0に設定した時のSPI Interfaceの波形と手順を以下に示します。
 
 .Quad I/O Read アクセス波形
 image::quad_io_read_acc_seq.png[quad_io_read_acc_seq]
 
 以下の手順は、メモリ 1にアクセスする場合のレジスタ設定例を示しています。
-Configuration Flash Memoryを除き、メモリ 2にアクセスする場合は、QSPI
-Access Control Registerの SPISSCTLを 0x01から 0x02に置き換えて下さい。
+Configuration Flash Memoryを除き、メモリ 2にアクセスする場合は、QSPI Access Control Registerの SPISSCTLを 0x01から 0x02に置き換えて下さい。
 
 A::
-  QSPI Access Control Registerを設定します。 SPI I/O
-  ModeはStandard(Single)-IO SPIモード、SPI SS
-  Controlは1とするため、0x00000001を書き込みます。
+  QSPI Access Control Registerを設定します。
+  SPI I/O ModeはStandard(Single)-IO SPIモード、SPI SS Controlは1とするため、0x00000001を書き込みます。
   書き込み後、SPI_CS信号がアクティブ状態 (Low level)に変化します。
 B::
-  QSPI TX Data Registerに 1 ByteのInstruction(Quad I/O
-  Read:0xEB)を書き込みます。
+  QSPI TX Data Registerに 1 ByteのInstruction(Quad I/O Read:0xEB)を書き込みます。
 C::
-  Bで書き込んだデータの送信完了後に、QSPI Access Control
-  Registerに0x00020001を書き込み、SPI I/O ModeをQuad-IO
-  SPIモードに変更します。
+  Bで書き込んだデータの送信完了後に、QSPI Access Control Registerに0x00020001を書き込み、SPI I/O ModeをQuad-IO SPIモードに変更します。
 D::
-  QSPI TX Data Registerに 3 Byteの Address、1 Byteの Modeを 1
-  Byte単位で書き込み、TX FIFOに格納します。 QSPI TX Data
-  Registerに書き込まれたデータからSPIデバイスに順次送信されます。
+  QSPI TX Data Registerに 3 Byteの Address、1 Byteの Modeを 1 Byte単位で書き込み、TX FIFOに格納します。
+  QSPI TX Data Registerに書き込まれたデータからSPIデバイスに順次送信されます。
   続けて、QSPI RX Data Registerに 4 Byte分の書き込みを行います。
-  この操作を行うことで、8 Cycleのダミーサイクル区間で
-  IO信号を入力モードにして SPIクロックを駆動します。
+  この操作を行うことで、8 Cycleのダミーサイクル区間で IO信号を入力モードにして SPIクロックを駆動します。
 E::
-  QSPI RX Data Registerの読み出しを 4 Byte分行い、ダミーサイクル区間に
-  RX FIFOに格納されたデータの読み出しを行います。
+  QSPI RX Data Registerの読み出しを 4 Byte分行い、ダミーサイクル区間に RX FIFOに格納されたデータの読み出しを行います。
   ダミーサイクル区間に格納されたデータは全て無効なデータであるため破棄してください。
-  4 Byte分全ての無効データの読み出しを行った後に、 QSPI RX Data
-  Registerに書き込みを行い Flash Memoryからの Readデータを RX
-  FIFOに格納します。 受信データはQSPI RX Data
-  Registerを読み出すことにより受信順に取得されます。 RX
-  FIFOは受信したデータを最大16Byteまで格納できます。 RX
-  FIFOの容量を超えるサイズのデータを受信する場合は、RX FIFOが
-  OverflowしないようQSPI TX Data
-  Registerの書き込みと読み出しの順序を考慮する必要があります。
-  RX_FIFOのデータ格納量のステータスは、QSPI FIFO Status
-  RegisterやRX_FIFO関連の割り込み要因により確認することができます。
+  4 Byte分全ての無効データの読み出しを行った後に、 QSPI RX Data Registerに書き込みを行い Flash Memoryからの Readデータを RX FIFOに格納します。
+  受信データはQSPI RX Data Registerを読み出すことにより受信順に取得されます。
+  RX FIFOは受信したデータを最大16Byteまで格納できます。
+  RX FIFOの容量を超えるサイズのデータを受信する場合は、RX FIFOが OverflowしないようQSPI TX Data Registerの書き込みと読み出しの順序を考慮する必要があります。
+  RX_FIFOのデータ格納量のステータスは、QSPI FIFO Status RegisterやRX_FIFO関連の割り込み要因により確認することができます。
 F::
-  Eで受信した全てのデータ読み出しの完了後に、QSPI Access Control
-  Registerに0x00000000を書き込みSPI_CS信号をインアクティブ状態 (High
-  level)に変化させ、SPIアクセスを終了します。
+  Eで受信した全てのデータ読み出しの完了後に、QSPI Access Control Registerに0x00000000を書き込みSPI_CS信号をインアクティブ状態 (High level)に変化させ、SPIアクセスを終了します。
 
-Data Write
-Operation時と同様、CからD時を除いた全てのフェーズの切り替わり時には、QSPI
-Controllerの実行ステータスを確認し、必ずIdle状態となってから次の操作を実行する必要があります。
+Data Write Operation時と同様、CからD時を除いた全てのフェーズの切り替わり時には、QSPI Controllerの実行ステータスを確認し、必ずIdle状態となってから次の操作を実行する必要があります。

--- a/modules/ROOT/pages/system_monitor.adoc
+++ b/modules/ROOT/pages/system_monitor.adoc
@@ -1,7 +1,6 @@
 == System Monitor
 
-System Monitorは、SC-OBC-A1
-FPGAのシステムを監視するためのモジュールです。
+System Monitorは、SC-OBC-A1 FPGAのシステムを監視するためのモジュールです。
 
 このモジュールは以下の機能を実装しています。
 
@@ -12,69 +11,44 @@ FPGAのシステムを監視するためのモジュールです。
 
 === FPGA Watchdog
 
-SC-OBC-A1 FPGAのシステムは、TRCHによって監視されます。 SC-OBC-A1 FPGAは
-System Monitorが収集した FPGA内部の状態を Watchdog signal
-(FPGA_WATCHDOG)を通じて TRCHに伝えます。 TRCHは FPGAが出力する
-FPGA_WATCHDOG信号が定期的にトグルしている間、FPGAが健全に動作していると判断します。
+SC-OBC-A1 FPGAのシステムは、TRCHによって監視されます。 SC-OBC-A1 FPGAは System Monitorが収集した FPGA内部の状態を Watchdog signal (FPGA_WATCHDOG)を通じて TRCHに伝えます。
+TRCHは FPGAが出力する FPGA_WATCHDOG信号が定期的にトグルしている間、FPGAが健全に動作していると判断します。
 
 === SEM Controller
 
-SEM (Soft Error Mitigation) Controllerは、AMD (旧 Xilinx)
-FPGAのコンフィギュレーションメモリで発生したソフトエラーの検出
-及び訂正を行う、AMD (旧 Xilinx) から提供されるソリューションです。
-SC-OBC-A1 FPGAはこの機能をシステムに組み込み、SEM Controllerの状態を
-System Monitorのレジスタから読み出す機能を持っています。
+SEM (Soft Error Mitigation) Controllerは、AMD (旧 Xilinx) FPGAのコンフィギュレーションメモリで発生したソフトエラーの検出 及び訂正を行う、AMD (旧 Xilinx) から提供されるソリューションです。
+SC-OBC-A1 FPGAはこの機能をシステムに組み込み、SEM Controllerの状態を System Monitorのレジスタから読み出す機能を持っています。
 
-CPUが正常に動作している場合でも、SEM
-Controllerが訂正不能なエラーを検出した場合や、SEM
-Controller自体に障害が発生した場合には、SC-OBC-A1
-FPGAに深刻な障害が発生する可能性があります。
+CPUが正常に動作している場合でも、SEM Controllerが訂正不能なエラーを検出した場合や、SEM Controller自体に障害が発生した場合には、SC-OBC-A1 FPGAに深刻な障害が発生する可能性があります。
 そのため、深刻な障害が発生する前に再起動することにより、システムを健全な状態に保つ事が可能です。
 
 SC-OBC-A1 FPGAは以下の構成でSEM Controllerを実装しています。
 
 [cols=",,",options="header",]
+[cols="4,3,13",options="header",]
 |===
-|項目 |設定 |説明
-|エラー訂正/修復方法 |拡張修復 |ECCおよび
-CRCアルゴリズムに基づく訂正を行います。1ビットのエラーまたは、隣接する
-2ビットのエラーを訂正します。
-
-|エラー分類機能 |未サポート
-|検出したすべてのエラーがエッセンシャルビットか非エッセンシャルビットかの分類はできません。全てエッセンシャルビットと判断します。
-
-|エラーモニタ機能 |未サポート |SEM
-Controllerが持つモニターインタフェースは実装していません。System
-Monitorのレジスタから簡易的なステータスを参照することにより、SEM
-Controllerを管理します。
-
-|エラー挿入機能 |サポート
-|ソフトウェアのテストのため、エラーを強制的に挿入する機能を持っています。
+|項目                |設定       |説明
+|エラー訂正/修復方法 |拡張修復   |ECCおよび CRCアルゴリズムに基づく訂正を行います。1ビットのエラーまたは、隣接する 2ビットのエラーを訂正します。
+|エラー分類機能      |未サポート |検出したすべてのエラーがエッセンシャルビットか非エッセンシャルビットかの分類はできません。全てエッセンシャルビットと判断します。
+|エラーモニタ機能    |未サポート |SEM Controllerが持つモニターインタフェースは実装していません。System Monitorのレジスタから簡易的なステータスを参照することにより、SEM Controllerを管理します。
+|エラー挿入機能      |サポート   |ソフトウェアのテストのため、エラーを強制的に挿入する機能を持っています。
 |===
 
-SEM Controllerの仕様詳細については、AMD (旧 Xilinx) ドキュメント「PG036:
-LogicCORE IP Soft Error Mitigation Controller v4.1
-製品ガイド」を参照してください。
+SEM Controllerの仕様詳細については、AMD (旧 Xilinx) ドキュメント「PG036: LogicCORE IP Soft Error Mitigation Controller v4.1製品ガイド」を参照してください。
 
 ==== SEM Controller Interrupt
 
-SEM Controllerは 4つの要因の割り込みを出力します。 SEM
-Controllerの割り込みは、System Monitor Interrupt Registerのビット
-11:8にマッピングされています。
+SEM Controllerは 4つの要因の割り込みを出力します。 SEM Controllerの割り込みは、System Monitor Interrupt Registerのビット 11:8にマッピングされています。
 
 * SEM Error Correction Interrupt
 
-SEM
-Controllerがコンフィギュレーションメモリのエラーを検知し、訂正・修復した事を示す通知ビットです。
-この割り込みは、SEM
-Controllerが正常にコンフィギュレーションメモリのエラーを訂正し修復した事を示すものであり、システムは健全に保たれている事を示します。
-この割り込みがセットされる時、SEM Error Correction Count Registerの値が
-+1されます。
+SEM Controllerがコンフィギュレーションメモリのエラーを検知し、訂正・修復した事を示す通知ビットです。
+この割り込みは、SEM Controllerが正常にコンフィギュレーションメモリのエラーを訂正し修復した事を示すものであり、システムは健全に保たれている事を示します。
+この割り込みがセットされる時、SEM Error Correction Count Registerの値が +1されます。
 
 * SEM Uncorrectable Interrupt
 
-SEM
-Controllerがコンフィギュレーションメモリに訂正不能なエラーを検出した事を示す通知ビットです。
+SEM Controllerがコンフィギュレーションメモリに訂正不能なエラーを検出した事を示す通知ビットです。
 この割り込みが発生した時、コンフィギュレーションメモリには障害が発生しています。
 エッセンシャルビットに障害が起きた場合、FPGAの回路が不正な状態となっている可能性があります。
 そのため、このエラーが発生した場合はシステムを再起動する事を推奨します。
@@ -82,42 +56,31 @@ Controllerがコンフィギュレーションメモリに訂正不能なエラ�
 * SEM Halted Interrupt
 
 SEM Controllerが Haltした事を示す通知ビットです。
-この割り込みは何らかの異常により、SEM
-Controllerに自体に障害が起き、動作を停止した事を示します。
-このエラーが発生した後は、SEM
-Controllerによるコンフィギュレーションメモリのエラー検出と訂正は行われません。
+この割り込みは何らかの異常により、SEM Controllerに自体に障害が起き、動作を停止した事を示します。
+このエラーが発生した後は、SEM Controllerによるコンフィギュレーションメモリのエラー検出と訂正は行われません。
 そのため、このエラーが発生した場合はシステムを再起動する事を推奨します。
 
 * SEM Heartbeat Timeout Interrupt
 
 SEM Controllerの Heartbeat信号が停止した事を示す通知ビットです。
-この割り込みは何らかの異常により、SEM
-Controllerに障害が起き、Heartbeat信号を出力できなくなった事を示します。
-このエラーが発生した後は、SEM
-Controllerが正常に動作していない可能性があります。
+この割り込みは何らかの異常により、SEM Controllerに障害が起き、Heartbeat信号を出力できなくなった事を示します。
+このエラーが発生した後は、SEM Controllerが正常に動作していない可能性があります。
 そのため、このエラーが発生した場合はシステムを再起動する事を推奨します。
 
 === Board Health Monitor (BHM)
 
-Board Health Monitor (BHM)は、OBC
-Module上に搭載するセンサーから簡単にデータを取得するための機能です。
+Board Health Monitor (BHM)は、OBC Module上に搭載するセンサーから簡単にデータを取得するための機能です。
 
-OBC Moduleには、2つの Current Voltage Monitorと 3つの
-温度センサーを搭載しています。 これらのセンサーは I2C規格のバスで
-SC-OBC-A1 FPGAと接続されています。
+OBC Moduleには、2つの Current Voltage Monitorと 3つの 温度センサーを搭載しています。
+これらのセンサーは I2C規格のバスで SC-OBC-A1 FPGAと接続されています。
 BHMはセンサーにアクセスするためのシーケンサーが実装されており、センサーからのデータをレジスタに格納します。
 これにより、ソフトウェアによる煩雑な処理を実行しなくても、センサーからデータを取得する事ができます。
 
-BHMが、センサーからデータを取得するタイミングは General Purpose Timerの
-Hardware Interrupt Timerによって決定します。 Hardware Interrupt Timerを
-Hardware
-Schedulerとして動作させる事で、BHMに定期的にセンサーデータの取得トリガを生成します。
-BHMは、センサーのデータ取得トリガを検出したタイミングで、センサーに対する
-I2Cアクセスを行い データを取得します。
+BHMが、センサーからデータを取得するタイミングは General Purpose Timerの Hardware Interrupt Timerによって決定します。
+Hardware Interrupt Timerを Hardware Schedulerとして動作させる事で、BHMに定期的にセンサーデータの取得トリガを生成します。
+BHMは、センサーのデータ取得トリガを検出したタイミングで、センサーに対する I2Cアクセスを行い データを取得します。
 
-尚、Current Voltage Monitorは Texas Instruments社の
-INA3221-Q1、温度センサーは Texas Instruments社の
-TMP175-Q1を搭載しています。
+尚、Current Voltage Monitorは Texas Instruments社の INA3221-Q1、温度センサーは Texas Instruments社の TMP175-Q1を搭載しています。
 センサーやセンサーからの取得データの詳細は、各データのデータシートを参照してください。
 
 ==== BHMの I2Cアクセス
@@ -126,183 +89,96 @@ BHMは 3つの I2Cアクセスを行うことができます。
 
 センサーデバイスの初期化
 
-* レジスタアクセスによりセンサーの初期化要求を発行すると、センサーの初期化のための
-I2Cアクセスを行います
-* センサーの初期化を行うアドレスや初期化データは、RTL設計時に
-Verilogのパラメータで設定する事ができます
+* レジスタアクセスによりセンサーの初期化要求を発行すると、センサーの初期化のための I2Cアクセスを行います
+* センサーの初期化を行うアドレスや初期化データは、RTL設計時に Verilogのパラメータで設定する事ができます
 
 センサーデータの取得
 
-* Hardware
-Schedulerからのトリガを検出すると、センサーからデータを取得するための
-I2Cアクセスを行います
-* Current Voltage Monitorからのデータ取得は、General Purpose Timerの
-Hardware Interrupt Timer Output Compare Channel
-2が発生するトリガで開始されます
-* 温度センサーからのデータ取得は、General Purpose Timerの Hardware
-Interrupt Timer Output Compare Channel 3が発生するトリガで開始されます
+* Hardware Schedulerからのトリガを検出すると、センサーからデータを取得するための I2Cアクセスを行います
+* Current Voltage Monitorからのデータ取得は、General Purpose Timerの Hardware Interrupt Timer Output Compare Channel 2が発生するトリガで開始されます
+* 温度センサーからのデータ取得は、General Purpose Timerの Hardware Interrupt Timer Output Compare Channel 3が発生するトリガで開始されます
 
 ソフトウェア指示による I2Cアクセス
 
-* ランタイムでセンサーの設定を変更したり、センサーが出力した
-Alertをクリアする目的で、簡単なレジスタアクセスで任意の
-I2Cアクセスを行います
+* ランタイムでセンサーの設定を変更したり、センサーが出力した Alertをクリアする目的で、簡単なレジスタアクセスで任意の I2Cアクセスを行います
 
 ==== センサー構成
 
-BHMに接続するセンサーと、BHMによって取得されるセンサーデータ 及び
-センサーデータが格納されるレジスタアドレスの一覧を以下に示します
+BHMに接続するセンサーと、BHMによって取得されるセンサーデータ 及びセンサーデータが格納されるレジスタアドレスの一覧を以下に示します
 
 [cols=",,,,",options="header",]
 |===
-|センサー |センサーデバイス |センサーレジスタアドレス |センサーデータ
-|BHMレジスタアドレスオフセット
-|Current Voltage Monitor 1 |INA3221-Q1 |0x01 |VDD_1V0 Shunt Voltage
-|0x2020
-
-| | |0x02 |VDD_1V0 Bus Voltage |0x2024
-
-| | |0x03 |VDD_1V8 Shunt Voltage |0x2028
-
-| | |0x04 |VDD_1V8 Bus Voltage |0x202C
-
-| | |0x05 |VDD_3V3 Shunt Voltage |0x2030
-
-| | |0x06 |VDD_3V3 Bus Voltage |0x2034
-
-|Current Voltage Monitor 2 |INA3221-Q1 |0x01 |VDD_3V3SYSA Shunt Voltage
-|0x2038
-
-| | |0x02 |VDD_3V3SYSA Bus Voltage |0x203C
-
-| | |0x03 |VDD_3V3SYSB Shunt Voltage |0x2040
-
-| | |0x04 |VDD_3V3SYSB Bus Voltage |0x2044
-
-| | |0x05 |VDD_3V3IO Shunt Voltage |0x2048
-
-| | |0x06 |VDD_3V3IO Bus Voltage |0x204C
-
-|Temperature Sensor 1 |TMP175-Q1 |0x00 |Temperature |0x2050
-
-|Temperature Sensor 2 |TMP175-Q1 |0x00 |Temperature |0x2054
-
-|Temperature Sensor 3 |TMP175-Q1 |0x00 |Temperature |0x2058
+     |センサー                          |センサーデバイス |センサーレジスタアドレス |センサーデータ            |BHMレジスタアドレスオフセット
+.6+<.<|Current Voltage Monitor 1  .6+<.<|INA3221-Q1       |0x01                     |VDD_1V0 Shunt Voltage     |0x2020
+                                                   |0x02                     |VDD_1V0 Bus Voltage       |0x2024
+                                                   |0x03                     |VDD_1V8 Shunt Voltage     |0x2028
+                                                   |0x04                     |VDD_1V8 Bus Voltage       |0x202C
+                                                   |0x05                     |VDD_3V3 Shunt Voltage     |0x2030
+                                                   |0x06                     |VDD_3V3 Bus Voltage       |0x2034
+.6+<.<|Current Voltage Monitor 2  .6+<.<|INA3221-Q1       |0x01                     |VDD_3V3SYSA Shunt Voltage |0x2038
+                                                   |0x02                     |VDD_3V3SYSA Bus Voltage   |0x203C
+                                                   |0x03                     |VDD_3V3SYSB Shunt Voltage |0x2040
+                                                   |0x04                     |VDD_3V3SYSB Bus Voltage   |0x2044
+                                                   |0x05                     |VDD_3V3IO Shunt Voltage   |0x2048
+                                                   |0x06                     |VDD_3V3IO Bus Voltage     |0x204C
+     |Temperature Sensor 1              |TMP175-Q1        |0x00                     |Temperature               |0x2050
+     |Temperature Sensor 2              |TMP175-Q1        |0x00                     |Temperature               |0x2054
+     |Temperature Sensor 3              |TMP175-Q1        |0x00                     |Temperature               |0x2058
 |===
 
 ==== センサーデータ自動取得のためのレジスタアクセス手順
 
-この章では、SC-OBC-A1 FPGAのシステムが起動してから、BHMによって Current
-Voltage Monitorと
-温度センサーから、センサーデータを自動取得させるためのレジスタアクセス手順を説明します。
+この章では、SC-OBC-A1 FPGAのシステムが起動してから、BHMによって Current Voltage Monitorと温度センサーから、センサーデータを自動取得させるためのレジスタアクセス手順を説明します。
 
-BHMによるセンサーデータの自動取得を開始するためには、a) BHMの初期化、b)
-センサーデバイスの初期化、c) General Purpose Timerの初期化、d)
-BHMサービス開始 の処理を行う必要があります。 本手順では、General Purpose
-Timerの初期化も行います。 General Purpose
-Timerのレジスタ仕様の詳細は「General Purpose
-Timer」の章を参照してください。
+BHMによるセンサーデータの自動取得を開始するためには、a) BHMの初期化、b)センサーデバイスの初期化、c) General Purpose Timerの初期化、d)BHMサービス開始 の処理を行う必要があります。
+本手順では、General Purpose Timerの初期化も行います。
+General Purpose Timerのレジスタ仕様の詳細は「General Purpose Timer」の章を参照してください。
 
 .センサーデータ自動取得のためのレジスタアクセス手順
 image::bhm_initilize.png[bhm_initilize]
 
-1: BHM Prescaler Registerに I2Cの通信速度を設定します
-
-I2Cの通信速度は、必ず Standard-mode (100Kb/s)以下にしてください
-Standard-mode以上の速度にすると、正しく通信できない場合があります。 BHM
-Prescaler Registerの初期値は、システムクロックが 48 MHzの場合に 100
-Kb/sとなる 0x77に設定されています。 システムクロックが 48
-MHzの場合は、特に理由が無い限り設定値を 0x77のままにしてください。
-
-2: BHM Retry Count Registerに I2C通信のリトライ回数を設定します
-
+. BHM Prescaler Registerに I2Cの通信速度を設定します
+I2Cの通信速度は、必ず Standard-mode (100Kb/s)以下にしてください Standard-mode以上の速度にすると、正しく通信できない場合があります。
+BHM Prescaler Registerの初期値は、システムクロックが 48 MHzの場合に 100 Kb/sとなる 0x77に設定されています。
+システムクロックが 48 MHzの場合は、特に理由が無い限り設定値を 0x77のままにしてください。
+. BHM Retry Count Registerに I2C通信のリトライ回数を設定します
 BHMは、I2C通信を行ったときにエラーを検出すると、このレジスタで設定した回数の自動リトライを行います。
 BHM Retry Count Registerの初期値は リトライ回数 "2"に設定されています。
-
-3: BHM Interrupt Enable Registerに 割り込みの有効化設定をします
-
-本手順を実行するためには、最低限 Bit 0と Bit 13:8を設定してください。
-
-4: BHM Initialization Access Control
-Registerの書き込み、センサーデバイスの書き込みを開始します
-
-初期化を行う対象の INITENビットと BHM_INITREQビットに
-"1"をセットする事でデバイスの初期化が開始されます。
-
-5:
-SYSMON_BHMINT割り込みにより、センサーデバイスの初期化完了を検出します
-
-SYSMON_BHMINT割り込み発生時、BHM Interrupt Status Registerの
-BHM_INITACCENDビットが
-"1"にセットされているとき、デバイスの初期化が完了したと判断できます。
-この時、BHM Interrupt Status Registerの Bit 12:8の
-I2CERRビットがセットされていない事を確認してください。
-I2CERRビットがセットされている場合、手順 2で設定した
-I2C通信のリトライ回数を超えるエラーが発生した事を示します。
-
-6: BHM Interrupt Status Registerの BHM_INTACCENDビットに
-"1"を書き込み、割り込みをクリアしてください
-
-7: Hardware Interrupt Timer Control Registerに、Hardware
-Interruptの発生方式を設定します
-
+. BHM Interrupt Enable Registerに 割り込みの有効化設定をします本手順を実行するためには、最低限 Bit 0と Bit 13:8を設定してください。
+. BHM Initialization Access Control Registerの書き込み、センサーデバイスの書き込みを開始します
+初期化を行う対象の INITENビットと BHM_INITREQビットに "1"をセットする事でデバイスの初期化が開始されます。
+. SYSMON_BHMINT割り込みにより、センサーデバイスの初期化完了を検出します
+SYSMON_BHMINT割り込み発生時、BHM Interrupt Status Registerの BHM_INITACCENDビットが "1"にセットされているとき、デバイスの初期化が完了したと判断できます。
+この時、BHM Interrupt Status Registerの Bit 12:8の I2CERRビットがセットされていない事を確認してください。
+I2CERRビットがセットされている場合、手順 2で設定した I2C通信のリトライ回数を超えるエラーが発生した事を示します。
+. BHM Interrupt Status Registerの BHM_INTACCENDビットに "1"を書き込み、割り込みをクリアしてください
+. Hardware Interrupt Timer Control Registerに、Hardware Interruptの発生方式を設定します
 レジスタの設定は、必ず次の通りに設定してください。
-GPTMR_HITRUNMDビットを Restartモード (設定値
-0b0)、GPTMR_HITOPMD2/GPTMR_HITOPMD3フィールド パルス割り込み出力
-(設定値 0b10)。 GPTMR_HITOPMD2の設定は Current Voltage
-Monitorからのデータを取得するために設定する必要があり、GPTMR_HITOPMD3の設定は
-温度センサーからデータを取得するために設定する必要があります。
+GPTMR_HITRUNMDビットを Restartモード (設定値 0b0)、GPTMR_HITOPMD2/GPTMR_HITOPMD3フィールド パルス割り込み出力 (設定値 0b10)。
+GPTMR_HITOPMD2の設定は Current Voltage Monitorからのデータを取得するために設定する必要があり、GPTMR_HITOPMD3の設定は温度センサーからデータを取得するために設定する必要があります。
+. Hardware Interrupt Timer Prescaler Registerに、Hardware Interrupt Timerのプリスケーラー設定を行います Hardware Inerrupt Timerの動作クロックは 24 MHzです。 設定方法の詳細は Hardware Interrupt Timerのレジスタ設定を参照してください。
+. Hardware Interrupt Timer Output Compare Register 1 に、Hardware Interrupt Timerの周期を設定します
+. Hardware Interrupt Timer Output Compare Register 2 に、Current Voltage Monitorのセンサーデータ取得タイミングを設定します
+. Hardware Interrupt Timer Output Compare Register 3 に、温度センサーのセンサーデータ取得タイミングを設定します
+. BHM Access Control Registerの MONIENビットを "1"にセットし、各センサーからのデータの自動取得を有効化します
+. Timer Enable Control Registerの HITENビットを"1"に設定し、Hardware Interrupt Timerの動作を開始します
 
-8: Hardware Interrupt Timer Prescaler Registerに、Hardware Interrupt
-Timerのプリスケーラー設定を行います
+12、13の処理が完了すると、BHMは Hardware Interrupt Timerが生成するタイミングで、センサーに対し I2C通信を行いセンサーデータを取得します。
+BHMがセンサーデバイスから取得したデータは、Monitor Registerに格納されます。
 
-Hardware Inerrupt Timerの動作クロックは 24 MHzです。 設定方法の詳細は
-Hardware Interrupt Timerのレジスタ設定を参照してください。
-
-9: Hardware Interrupt Timer Output Compare Register 1 に、Hardware
-Interrupt Timerの周期を設定します
-
-10: Hardware Interrupt Timer Output Compare Register 2 に、Current
-Voltage Monitorのセンサーデータ取得タイミングを設定します
-
-11: Hardware Interrupt Timer Output Compare Register 3
-に、温度センサーのセンサーデータ取得タイミングを設定します
-
-12: BHM Access Control Registerの MONIENビットを
-"1"にセットし、各センサーからのデータの自動取得を有効化します
-
-13: Timer Enable Control Registerの HITENビットを"1"に設定し、Hardware
-Interrupt Timerの動作を開始します
-
-12、13の処理が完了すると、BHMは Hardware Interrupt
-Timerが生成するタイミングで、センサーに対し
-I2C通信を行いセンサーデータを取得します。
-BHMがセンサーデバイスから取得したデータは、Monitor
-Registerに格納されます。
-
-以下に Hardware Interrupt Timerの周期を 1秒とし、Current Voltage
-Monitorの読み出しタイミングを 100 ms、温度センサーの読み出しタイミングを
-200 msとした場合のレジスタ設定を示します。
+以下に Hardware Interrupt Timerの周期を 1秒とし、Current Voltage Monitorの読み出しタイミングを 100 ms、温度センサーの読み出しタイミングを 200 msとした場合のレジスタ設定を示します。
 
 .Hardware Interrupt Timerを 1秒周期にした時の、センサーデータ自動受信の例
 image::bhm_hardware_interrupt_timing.png[bhm_hardware_interrupt_timing]
 
-* 手順 8で行う Hardware Interrupt Timer Prescaler Registerに
-0x5DBFを設定する事で Hardware Interrupt Timerのカウントアップ時間を
-1msとする
-* 手順 9で行う Hardware Interrupt Timer Output Compare Register 1に
-0x3E8を設定する事で Hardware Interrupt Timerの周期を 1秒とする
-* 手順 10で行う Hardware Interrupt Timer Output Compare Register 2に
-0x64を設定する事で、Current Voltage
-Monitorのデータ読み出し開始タイミングを 100 msとする
-* 手順 11で行う Hardware Interrupt Timer Output Compare Register 3に
-0xC8を設定する事で、温度センサーのデータ読み出し開始タイミングを 200
-msとする
+* 手順 8で行う Hardware Interrupt Timer Prescaler Registerに 0x5DBFを設定する事で Hardware Interrupt Timerのカウントアップ時間を 1msとする
+* 手順 9で行う Hardware Interrupt Timer Output Compare Register 1に 0x3E8を設定する事で Hardware Interrupt Timerの周期を 1秒とする
+* 手順 10で行う Hardware Interrupt Timer Output Compare Register 2に 0x64を設定する事で、Current Voltage Monitorのデータ読み出し開始タイミングを 100 msとする
+* 手順 11で行う Hardware Interrupt Timer Output Compare Register 3に 0xC8を設定する事で、温度センサーのデータ読み出し開始タイミングを 200 msとする
 
-Current Voltage Monitorのデータ読み出しは 6 ms、温度センサーの読み出しは
-1.5 msかかります。 そのため、Hardware Interrupt Timerの周期は 7.5
-msより大きな時間に設定してください。 また、各センサーデバイスには
-AD変換時間があり、短い周期でデータを読み出した場合には、まだセンサーデバイスのデータ更新が行われていない場合があります。
+Current Voltage Monitorのデータ読み出しは 6 ms、温度センサーの読み出しは 1.5 msかかります。
+そのため、Hardware Interrupt Timerの周期は 7.5 msより大きな時間に設定してください。
+また、各センサーデバイスには AD変換時間があり、短い周期でデータを読み出した場合には、まだセンサーデバイスのデータ更新が行われていない場合があります。
 
 詳細は各センサーデバイスのデータシートを参照してください。
 
@@ -310,207 +186,97 @@ AD変換時間があり、短い周期でデータを読み出した場合には
 
 この章では、BHMによるセンサーデバイスの初期化のためのレジスタアクセス手順について説明します。
 
-BHMは、ソフトウェアからのレジスタアクセスにより、センサーデバイスの初期化要求を受けると、I2Cアクセスを行い
-センサーデバイスに初期設定値を書き込みます。
+BHMは、ソフトウェアからのレジスタアクセスにより、センサーデバイスの初期化要求を受けると、I2Cアクセスを行いセンサーデバイスに初期設定値を書き込みます。
 センサーデバイスの初期化のためのレジスタアクセス手順を以下に示します。
 
 .センサーデバイスの初期化のためのレジスタアクセス手順
 image::bhm_sensor_init.png[bhm_sensor_init]
 
-1: BHM Initialization Access Control
-Registerの初期化を行うセンサーデバイスに対応する Initialization Enableと
-INIT_REQビットをセットします。
-INIT_REQビットをセットされると、Initialization
-Enableがセットされたセンサーデバイスへの初期化のための
-I2Cアクセスが開始されます。
-
-2:
-BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
-割り込みを検出したとき、BHM Interrupt Status Registerの
-BHM_INITACCENDビットがセットされている場合、センサーデバイスの初期化のための
-I2Cアクセスが完了した事を示します。
-BHM_INITACCENDがセットされたときは、I2CERRビットの確認を行い
-I2Cアクセスにエラーが発生したかどうかを確認します。
+. BHM Initialization Access Control Registerの初期化を行うセンサーデバイスに対応する Initialization Enableと INIT_REQビットをセットします。
+INIT_REQビットをセットされると、Initialization Enableがセットされたセンサーデバイスへの初期化のための I2Cアクセスが開始されます。
+. BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
+割り込みを検出したとき、BHM Interrupt Status Registerの BHM_INITACCENDビットがセットされている場合、センサーデバイスの初期化のための I2Cアクセスが完了した事を示します。
+BHM_INITACCENDがセットされたときは、I2CERRビットの確認を行い I2Cアクセスにエラーが発生したかどうかを確認します。
 I2CERRビットがセットされていないとき、そのセンサーデバイスのアクセスは正常に完了したと判断できます。
-
-3: Board Health Interrupt Status RegisterのBHM_SWACCENDビットに
-"1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
+. Board Health Interrupt Status RegisterのBHM_SWACCENDビットに "1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
 
 以下に、初期設定を行うセンサーデバイス、デバイスアドレス、初期設定値の一覧を示します。
-尚、初期設定値は、RTL設計において Verilog
-Parameterで変更する事ができます。
+尚、初期設定値は、RTL設計において Verilog Parameterで変更する事ができます。
 
 .デバイス初期設定一覧 (default)
-[cols=",,,",options="header",]
+[cols="3,4,2,11",options="header",]
 |===
-|Device |Address |初期設定値 |Description
-|Current Voltage Monitor1 |0x07: Channel-1 Critical-Alert Limit |0x2710
-|VDD_1V0の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
-
-|Current Voltage Monitor1 |0x08: Channel-1 Warning-Alert Limit |0x1770
-|VDD_1V0の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
-
-|Current Voltage Monitor1 |0x09: Channel-2 Critical-Alert Limit |0x2710
-|VDD_1V8の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
-
-|Current Voltage Monitor1 |0x0A: Channel-2 Warning-Alert Limit |0x1770
-|VDD_1V8の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
-
-|Current Voltage Monitor1 |0x0B: Channel-3 Critical-Alert Limit |0x2710
-|VDD_3V3の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
-
-|Current Voltage Monitor1 |0x0C: Channel-3 Warning-Alert Limit |0x1770
-|VDD_3V3の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
-
-|Current Voltage Monitor1 |0x0F: Mask/Enable |0x0C00 |Current Voltage
-Monitor 1の Critical-Alertピン、Warning-Alertピンのラッチの有効化を設定
-
-|Current Voltage Monitor2 |0x07: Channel-1 Critical-Alert Limit |0x2710
-|VDD_3V3SYSAの Critical-Alertをシャント電圧: 50mV (シャント電流:
-5A)に設定
-
-|Current Voltage Monitor2 |0x08: Channel-1 Warning-Alert Limit |0x1770
-|VDD_3V3SYSAの Warning-Alertをシャント電圧: 30mV (シャント電流:
-3A)に設定
-
-|Current Voltage Monitor2 |0x09: Channel-2 Critical-Alert Limit |0x2710
-|VDD_3V3SYSBの Critical-Alertをシャント電圧: 50mV (シャント電流:
-5A)に設定
-
-|Current Voltage Monitor2 |0x0A: Channel-2 Warning-Alert Limit |0x1770
-|VDD_3V3SYSBの Warning-Alertをシャント電圧: 30mV (シャント電流:
-3A)に設定
-
-|Current Voltage Monitor2 |0x0B: Channel-3 Critical-Alert Limit |0x2710
-|VDD_3V3IOの Critical-Alertをシャント電圧: 50mV (シャント電流:
-5A)に設定
-
-|Current Voltage Monitor2 |0x0C: Channel-3 Warning-Alert Limit |0x1770
-|VDD_3V3IOの Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
-
-|Current Voltage Monitor2 |0x0F: Mask/Enable |0x0C00 |Current Voltage
-Monitor 2の Critical-Alertピン、Warning-Alertピンのラッチの有効化を設定
-
-|Temperature Sensor1 |0x01: Configuration register |0x0200 |Temperature
-Sensor 1の ALERTピンの動作を Interrupt Modeに設定
-(1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
-
-|Temperature Sensor1 |0x02: TLOW register |0x4B00 |Temperature Sensor
-1の TLOWを 75℃に設定
-
-|Temperature Sensor1 |0x03: THIGH register |0x5000 |Temperature Sensor
-1の THIGHを 80℃に設定
-
-|Temperature Sensor2 |0x01: Configuration register |0x0200 |Temperature
-Sensor 2の ALERTピンの動作を Interrupt Modeに設定
-(1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
-
-|Temperature Sensor2 |0x02: TLOW register |0x4B00 |Temperature Sensor
-2の TLOWを 75℃に設定
-
-|Temperature Sensor2 |0x03: THIGH register |0x5000 |Temperature Sensor
-2の THIGHを 80℃に設定
-
-|Temperature Sensor3 |0x01: Configuration register |0x0200 |Temperature
-Sensor 3の ALERTピンの動作を Interrupt Modeに設定
-(1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
-
-|Temperature Sensor3 |0x02: TLOW register |0x4B00 |Temperature Sensor
-3の TLOWを 75℃に設定
-
-|Temperature Sensor3 |0x03: THIGH register |0x5000 |Temperature Sensor
-3の THIGHを 80℃に設定
+|Device                   |Address                              |初期設定値 |Description
+|Current Voltage Monitor1 |0x07: Channel-1 Critical-Alert Limit |0x2710     |VDD_1V0の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor1 |0x08: Channel-1 Warning-Alert Limit  |0x1770     |VDD_1V0の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor1 |0x09: Channel-2 Critical-Alert Limit |0x2710     |VDD_1V8の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor1 |0x0A: Channel-2 Warning-Alert Limit  |0x1770     |VDD_1V8の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor1 |0x0B: Channel-3 Critical-Alert Limit |0x2710     |VDD_3V3の Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor1 |0x0C: Channel-3 Warning-Alert Limit  |0x1770     |VDD_3V3の Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor1 |0x0F: Mask/Enable                    |0x0C00     |Current Voltage Monitor 1の Critical-Alertピン、Warning-Alertピンのラッチの有効化を設定
+|Current Voltage Monitor2 |0x07: Channel-1 Critical-Alert Limit |0x2710     |VDD_3V3SYSAの Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor2 |0x08: Channel-1 Warning-Alert Limit  |0x1770     |VDD_3V3SYSAの Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor2 |0x09: Channel-2 Critical-Alert Limit |0x2710     |VDD_3V3SYSBの Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor2 |0x0A: Channel-2 Warning-Alert Limit  |0x1770     |VDD_3V3SYSBの Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor2 |0x0B: Channel-3 Critical-Alert Limit |0x2710     |VDD_3V3IOの Critical-Alertをシャント電圧: 50mV (シャント電流: 5A)に設定
+|Current Voltage Monitor2 |0x0C: Channel-3 Warning-Alert Limit  |0x1770     |VDD_3V3IOの Warning-Alertをシャント電圧: 30mV (シャント電流: 3A)に設定
+|Current Voltage Monitor2 |0x0F: Mask/Enable                    |0x0C00     |Current Voltage Monitor 2の Critical-Alertピン、Warning-Alertピンのラッチの有効化を設定
+|Temperature Sensor1      |0x01: Configuration register         |0x0200     |Temperature Sensor 1の ALERTピンの動作を Interrupt Modeに設定 (1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
+|Temperature Sensor1      |0x02: TLOW register                  |0x4B00     |Temperature Sensor 1の TLOWを 75℃に設定
+|Temperature Sensor1      |0x03: THIGH register                 |0x5000     |Temperature Sensor 1の THIGHを 80℃に設定
+|Temperature Sensor2      |0x01: Configuration register         |0x0200     |Temperature Sensor 2の ALERTピンの動作を Interrupt Modeに設定 (1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
+|Temperature Sensor2      |0x02: TLOW register                  |0x4B00     |Temperature Sensor 2の TLOWを 75℃に設定
+|Temperature Sensor2      |0x03: THIGH register                 |0x5000     |Temperature Sensor 2の THIGHを 80℃に設定
+|Temperature Sensor3      |0x01: Configuration register         |0x0200     |Temperature Sensor 3の ALERTピンの動作を Interrupt Modeに設定 (1Byteのレジスタの為、MSB Byteの書き込み値に設定される)
+|Temperature Sensor3      |0x02: TLOW register                  |0x4B00     |Temperature Sensor 3の TLOWを 75℃に設定
+|Temperature Sensor3      |0x03: THIGH register                 |0x5000     |Temperature Sensor 3の THIGHを 80℃に設定
 |===
 
-センサーデバイスの初期化のための I2Cアクセスの実行中に、BHM Retry Count
-Setting Registerに設定されている回数の I2Cエラーが発生した場合、BHM
-Interrupt Status Registerの対応するセンサーデバイスの
-I2CERRビットがセットされます。
+センサーデバイスの初期化のための I2Cアクセスの実行中に、BHM Retry Count Setting Registerに設定されている回数の I2Cエラーが発生した場合、BHM Interrupt Status Registerの対応するセンサーデバイスの I2CERRビットがセットされます。
 また、I2Cエラーが発生したデバイスへの以降の初期化設定はスキップされます。
-ひとつのセンサーデバイスに
-I2Cエラーが起きても、I2CERRビットがセットされていないセンサーの初期化アクセスは正常に完了しています。
+ひとつのセンサーデバイスに I2Cエラーが起きても、I2CERRビットがセットされていないセンサーの初期化アクセスは正常に完了しています。
 
 ==== ソフトウェア指示によるセンサーデバイスへの I2Cアクセス
 
-この章では、SC-OBC-A1 FPGAに実装されるセンサーデバイス (Current Voltage
-Monitor 及び
-温度センサー)に、ソフトウェアの指示によりアクセスする方法を説明します。
+この章では、SC-OBC-A1 FPGAに実装されるセンサーデバイス (Current Voltage Monitor 及び 温度センサー)に、ソフトウェアの指示によりアクセスする方法を説明します。
 
-BHMは、RTLに指定する Verilog
-parameterの値に従い、センサーデバイスのレジスタを初期化する機能を持っています。
-この機能とは別に、センサーデバイスのレジスタに対し 任意の
-I2Cアクセスを行いたい場合は、ソフトウェア指示によるセンサーデバイスへのアクセスを行います。
+BHMは、RTLに指定する Verilog parameterの値に従い、センサーデバイスのレジスタを初期化する機能を持っています。
+この機能とは別に、センサーデバイスのレジスタに対し 任意の I2Cアクセスを行いたい場合は、ソフトウェア指示によるセンサーデバイスへのアクセスを行います。
 
 ソフトウェア指示によりセンサーデバイスのレジスタにデータを書き込むためのレジスタアクセスフローを以下に示します。
 
 .ソフトウェア指示によるセンサーデバイスのレジスタ書き込みフロー
 image::bhm_sw_write_seq.png[bhm_sw_write_seq]
 
-1: センサーデバイスに書き込む 2 Byteのデータを BHM Software Access Write
-Data Registerに書き込みます。
+. センサーデバイスに書き込む 2 Byteのデータを BHM Software Access Write Data Registerに書き込みます。
 このレジスタに書き込まれたデータがそのままデバイスのレジスタに書き込まれます。
-
-2:
-レジスタ書き込みを行うセンサーデバイスとレジスタアドレスを設定するため、BHM
-Software Access Control Registerの BHM_SWDEVSELと
-BHM_SWREGADRを書き込みます。
-同時に、センサーデバイスへの書き込みアクセスを行うため、BHM_SWRWSELに
-"0" (Write Access)を設定し、BHM_SWACCREQに "1"をセットします。
-BHM_SWACCREQビットが
-"1"にセットされた事をきっかけに、BHMはセンサーデバイスへの
-I2Cアクセスを開始します。
-
-3:
-BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
-割り込みを検出したとき、BHM Interrupt Status Registerの
-BHM_SWACCENDビットがセットされている場合、ソフトウェア指示によるセンサーデバイスへの
-I2Cアクセスが正常に完了した事を示します。
-
-4: Board Health Interrupt Status RegisterのBHM_SWACCENDビットに
-"1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
-
-ソフトウェア指示によるセンサーデバイスのレジスタ書き込み中に、I2Cアクセスのエラーが発生した場合は、BHM
-Interrupt Status Registerの BHM_SWACCERRビットに
-"1"にセットされ、センサーデバイスへの I2Cアクセスは停止します。
-
+. レジスタ書き込みを行うセンサーデバイスとレジスタアドレスを設定するため、BHM Software Access Control Registerの BHM_SWDEVSELと BHM_SWREGADRを書き込みます。
+同時に、センサーデバイスへの書き込みアクセスを行うため、BHM_SWRWSELに "0" (Write Access)を設定し、BHM_SWACCREQに "1"をセットします。
+BHM_SWACCREQビットが "1"にセットされた事をきっかけに、BHMはセンサーデバイスへの I2Cアクセスを開始します。
+. BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
+割り込みを検出したとき、BHM Interrupt Status Registerの BHM_SWACCENDビットがセットされている場合、ソフトウェア指示によるセンサーデバイスへの I2Cアクセスが正常に完了した事を示します。
+. Board Health Interrupt Status RegisterのBHM_SWACCENDビットに "1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
+ソフトウェア指示によるセンサーデバイスのレジスタ書き込み中に、I2Cアクセスのエラーが発生した場合は、BHM Interrupt Status Registerの BHM_SWACCERRビットに "1"にセットされ、センサーデバイスへの I2Cアクセスは停止します。
 ソフトウェア指示によりセンサーデバイスのレジスタからデータを読み出すためのレジスタアクセスフローを以下に示します。
 
 .ソフトウェア指示によるセンサーデバイスからのレジスタ読み出しフロー
 image::bhm_sw_read_seq.png[bhm_sw_read_seq]
 
-1:
-レジスタ読み出しを行うセンサーデバイスとレジスタアドレスを設定するため、BHM
-Software Access Control Registerの BHM_SWDEVSELと
-BHM_SWREGADRを書き込みます。
-同時に、センサーデバイスからの読み出しアクセスを行うため、BHM_SWRWSELに
-"1" (Read Access)を設定し、BHM_SWACCREQに "1"をセットします。
-BHM_SWACCREQビットが
-"1"にセットされた事をきっかけに、BHMはセンサーデバイスへの
-I2Cアクセスを開始します。
-
-2:
-BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
-割り込みを検出したとき、BHM Interrupt Status Registerの
-BHM_SWACCENDビットがセットされている場合、ソフトウェア指示によるセンサーデバイスへの
-I2Cアクセスが正常に完了した事を示します。
-
-3: Board Health Interrupt Status RegisterのBHM_SWACCENDビットに
-"1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
-
-4: BHMがセンサーデバイスのレジスタから読み出したデータは、BHM Software
-Access Read Data Registerに格納されます。 BHM Software Access Read Data
-Registerを読み出す事で、センサーデバイスから読み出したデータを取得できます。
-
-ソフトウェア指示によるセンサーデバイスのレジスタ読み出し中に、I2Cアクセスのエラーが発生した場合は、BHM
-Interrupt Status Registerの BHM_SWACCERRビットが
-"1"にセットされ、センサーデバイスへの I2Cアクセスは停止します。
+. レジスタ読み出しを行うセンサーデバイスとレジスタアドレスを設定するため、BHM Software Access Control Registerの BHM_SWDEVSELと BHM_SWREGADRを書き込みます。
+同時に、センサーデバイスからの読み出しアクセスを行うため、BHM_SWRWSELに "1" (Read Access)を設定し、BHM_SWACCREQに "1"をセットします。
+BHM_SWACCREQビットが "1"にセットされた事をきっかけに、BHMはセンサーデバイスへの I2Cアクセスを開始します。
+. BHMによるセンサーデバイスへの書き込みアクセスの完了は、SYSMON_BHMINT割り込みのアサートにより検出する事ができます。
+割り込みを検出したとき、BHM Interrupt Status Registerの BHM_SWACCENDビットがセットされている場合、ソフトウェア指示によるセンサーデバイスへの I2Cアクセスが正常に完了した事を示します。
+. Board Health Interrupt Status RegisterのBHM_SWACCENDビットに "1"を書き込むと、BHM_SWACCENDビットをクリアする事ができます。
+. BHMがセンサーデバイスのレジスタから読み出したデータは、BHM Software Access Read Data Registerに格納されます。 BHM Software Access Read Data Registerを読み出す事で、センサーデバイスから読み出したデータを取得できます。
+ソフトウェア指示によるセンサーデバイスのレジスタ読み出し中に、I2Cアクセスのエラーが発生した場合は、BHM Interrupt Status Registerの BHM_SWACCERRビットが "1"にセットされ、センサーデバイスへの I2Cアクセスは停止します。
 
 === レジスタ詳細
 
 System Monitorは、Base Address 0x4F04_0000に配置されています。
 
 .System Monitorメモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset          |Symbol             |Register                                       |Initial
 |0x0000          |SYSMON_WDOGCTRL    |Watchdog Control Register                      |0x00075A5A
@@ -553,53 +319,41 @@ System Monitorは、Base Address 0x4F04_0000に配置されています。
 
 ==== Watchdog Control Register (Offset 0x0000)
 
-Watchdog Control Registerは、SC-OBC-A1 FPGAの
-Watchdogの制御を行うためのレジスタです。 本レジスタにより Watchdog
-Counterの満了時間の設定や、Software Watchdog
-Timerをリロードする事ができます。
+Watchdog Control Registerは、SC-OBC-A1 FPGAの Watchdogの制御を行うためのレジスタです。
+本レジスタにより Watchdog Counterの満了時間の設定や、Software Watchdog Timerをリロードする事ができます。
 
-システムの起動後、SC-OBC-A1 FPGAの Watchdog Timer回路は、TRCHに対し
-Watchdog信号のトグルを開始します。 ソフトウェアは Software Watcdog
-Timeフィールドに設定されている Software Watchdog
-Timerの満了時間以内に、Watchdog Service Registerにアクセスし Software
-Watchdog Timerをリロードする必要があります。 Software Watchdog
-Timerが満了すると、SC-OBC-A1 FPGAの Watchdog Timer回路は、TRCHに対する
-Watchdog信号のトグルを停止し、TRCHに対しソフトウェアに異常が起きた事を通知します。
+システムの起動後、SC-OBC-A1 FPGAの Watchdog Timer回路は、TRCHに対し Watchdog信号のトグルを開始します。
+ソフトウェアは Software Watcdog Timeフィールドに設定されている Software Watchdog Timerの満了時間以内に、Watchdog Service Registerにアクセスし Software Watchdog Timerをリロードする必要があります。
+Software Watchdog Timerが満了すると、SC-OBC-A1 FPGAの Watchdog Timer回路は、TRCHに対する Watchdog信号のトグルを停止し、TRCHに対しソフトウェアに異常が起きた事を通知します。
 
-初期状態では、Software Watchdog Timerのの満了時間は 128 [sec]
-に設定されています。 ソフトウェアが、定期的にSoftware Watchdog
-Timerをリロードできる状態となった後、Software Watchdog
-Timeフィールドを適切な値に変更する事で
-異常検知のタイミングを設定する事ができます。
+初期状態では、Software Watchdog Timerのの満了時間は 128 [sec] に設定されています。
+ソフトウェアが、定期的にSoftware Watchdog Timerをリロードできる状態となった後、Software Watchdog Timeフィールドを適切な値に変更する事で異常検知のタイミングを設定する事ができます。
 
 .Watchdog Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:19 |- |Reserved |Reserved |-
-
-|18:16 |SW_WDOGTIME |Software Watchdog Time |Software Watchdog
-Timerの満了時間を設定するためのフィールドです。0x0: 1 [sec] 0x1: 2 [sec]
-0x2: 4 [sec] 0x3: 8 [sec] 0x4: 16 [sec] 0x5: 32 [sec] 0x6: 64 [sec] 0x7:
-128 [sec] |R/W
-
-|15:0 |WDOG_WSR |Watchdog Service Register |Software Watchdog
-Timerをリロードするためのフィールドです。0x5A5Aと
-0xA5A5を交互に書き込む事で、Software Watchdog
-Timerをリロードする事ができます。このフィールドを読み出すと、Software
-Watchdog Timerをリロードするために次に書き込む値(0x5A5A または
-0xA5A5)を読み出す事ができます。 |R/W
+|bit   |Symbol      |Field                      |Description |R/W
+|31:19 |-           |Reserved                   |Reserved    |-
+|18:16 |SW_WDOGTIME |Software Watchdog Time     |Software Watchdog Timerの満了時間を設定するためのフィールドです。 +
+0x0: 1 [sec] +
+0x1: 2 [sec] +
+0x2: 4 [sec] +
+0x3: 8 [sec] +
+0x4: 16 [sec] +
+0x5: 32 [sec] +
+0x6: 64 [sec] +
+0x7: 128 [sec] |R/W
+|15:0  |WDOG_WSR    |Watchdog Service Register |Software Watchdog Timerをリロードするためのフィールドです。
+0x5A5Aと 0xA5A5を交互に書き込む事で、Software Watchdog Timerをリロードする事ができます。
+このフィールドを読み出すと、Software Watchdog Timerをリロードするために次に書き込む値(0x5A5A または 0xA5A5)を読み出す事ができます。 |R/W
 |===
 
 ==== Watchdog Signal Interval Register (Offset 0x0010)
 
-Watchdog Signal Interval
-Registerは、FPGA_WATCHDOG信号のトグル間隔を設定するためのレジスタです。
+Watchdog Signal Interval Registerは、FPGA_WATCHDOG信号のトグル間隔を設定するためのレジスタです。
 
-FPGA_WATCHDOGが Highレベル または
-Lowレベルとなるクロックサイクル数を規定します。Watchdog
-Signalのカウンタは 24
-MHzで動作するため、以下の式で設定値を求める事ができます。
+FPGA_WATCHDOGが Highレベル または Lowレベルとなるクロックサイクル数を規定します。
+Watchdog Signalのカウンタは 24 MHzで動作するため、以下の式で設定値を求める事ができます。
 
 [stem]
 ++++
@@ -609,196 +363,119 @@ WDOG\_SIVAL設定値 = \frac{FPGA\_WATCHDOG\ High/Lowレベル幅 [s]}{\frac{1}{
 .Watchdig Signal Interval Registerビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |- |Reserved |Reserved |-
-
-|23:0 |WDOG_SIVAL |Watchdog Signal Interval |Watchdog Signalの
-Highレベルまたは Lowレベルの幅を設定するフィールドです。初期値は 500
-[ms]に設定されています。 |R/W
+|bit   |Symbol     |Field                    |Description                                                                                                     |R/W
+|31:24 |-          |Reserved                 |Reserved                                                                                                        |-
+|23:0  |WDOG_SIVAL |Watchdog Signal Interval |Watchdog Signalの Highレベルまたは Lowレベルの幅を設定するフィールドです。初期値は 500 [ms]に設定されています。 |R/W
 |===
 
 ==== Clock Monitor Register (Offset 0x0020)
 
-Clock Monitor Registerは、SC-OBC-A1
-FPGAのクロック状態を示すレジスタです。
+Clock Monitor Registerは、SC-OBC-A1 FPGAのクロック状態を示すレジスタです。
 
 .Clock Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |PLL_LOCK |PLL Lock Status |SC-OBC-A1 FPGAの
-PLLの状態を示します。0: PLL Unlock 1: PLL LOCK |RO
-
-|15:13 |- |Reserved |Reserved |-
-
-|12 |UCLK2_STS |User Clock 2 Status |User Clock
-2のクロックの動作状態を示します。 0: クロック停止中 1: クロック動作中
-|RO
-
-|11 |UCLK1_STS |User Clock 1 Status |User Clock
-1のクロックの動作状態を示します。 0: クロック停止中 1: クロック動作中
-|RO
-
-|10 |ULPICLK_STS |ULPI Reference Clock Status |ULPI Reference
-Clockのクロックの動作状態を示します。 0: クロック停止中 1:
-クロック動作中 |RO
-
-|9 |MAXICLK_STS |Main AXI Clock Status |Main AXI
-Clockのクロックの動作状態を示します。 0: クロック停止中 1:
-クロック動作中 |RO
-
-|8 |SYSCLK_STS |System Clock Status |System
-Clockのクロックの動作状態を示します。 0: クロック停止中 1:
-クロック動作中 |RO
-
-|7:2 |- |Reserved |Reserved |-
-
-|1:0 |OSC_CLKEN |OSC Clock Enable |SC-OBC-A1 FPGAの入力クロック
-(源発信クロック)の Enable信号の状態を示します。bit 0: Oscillator
-1の状態を示します。 bit 1: Oscillator
-2の状態を示します。これらのビットが "1"の時、クロックは Enableです。 |RO
+|bit   |Symbol      |Field                       |Description                                                     |R/W
+|31:17 |-           |Reserved                    |Reserved                                                        |-
+|16    |PLL_LOCK    |PLL Lock Status             |SC-OBC-A1 FPGAの PLLの状態を示します。 +
+0: PLL Unlock +
+1: PLL LOCK |RO
+|15:13 |-           |Reserved |Reserved          |-
+|12    |UCLK2_STS   |User Clock 2 Status         |User Clock 2のクロックの動作状態を示します。 +
+0: クロック停止中 +
+1: クロック動作中 |RO
+|11    |UCLK1_STS   |User Clock 1 Status         |User Clock 1のクロックの動作状態を示します。 +
+0: クロック停止中 +
+1: クロック動作中 |RO
+|10    |ULPICLK_STS |ULPI Reference Clock Status |ULPI Reference Clockのクロックの動作状態を示します。 +
+0: クロック停止中 +
+1: クロック動作中 |RO
+|9     |MAXICLK_STS |Main AXI Clock Status       |Main AXI Clockのクロックの動作状態を示します。 +
+0: クロック停止中 +
+1: クロック動作中 |RO
+|8     |SYSCLK_STS  |System Clock Status         |System Clockのクロックの動作状態を示します。 +
+0: クロック停止中 +
+1: クロック動作中 |RO
+|7:2   |-           |Reserved                    |Reserved |-
+|1:0   |OSC_CLKEN   |OSC Clock Enable            |SC-OBC-A1 FPGAの入力クロック (源発信クロック)の Enable信号の状態を示します。 +
+bit 0: Oscillator 1の状態を示します。 +
+bit 1: Oscillator 2の状態を示します。 +
+これらのビットが "1"の時、クロックは Enableです。 |RO
 |===
 
 ==== Hardware Status 1/2 Register (Offset 0x0024/Offset 0x0028)
 
-Hardware Status Registerは、SC-OBC-A1
-FPGAのハードウェアの状態を示すレジスタです。
+Hardware Status Registerは、SC-OBC-A1 FPGAのハードウェアの状態を示すレジスタです。
 
 このレジスタは、ソフトウェアから見ると、Scratchpadとして動作します。
 Loaderによって、ハードウェアの健全性が確認されるとこのレジスタに書き込みを行います。
-Flight
-Softwareは、起動時にこのレジスタを読み出す事で、ハードウェアの健全性を知る事ができます。
+Flight Softwareは、起動時にこのレジスタを読み出す事で、ハードウェアの健全性を知る事ができます。
 
-このレジスタは、SC-OBC-A1 FPGAの
-Configuration後に一度だけ初期化されます。 Code Memory Select Registerの
-ITCMENビットがセットされた時に発行されるシステムリセットでは、このレジスタはクリアされません。
-
+このレジスタは、SC-OBC-A1 FPGAの Configuration後に一度だけ初期化されます。 Code Memory Select Registerの ITCMENビットがセットされた時に発行されるシステムリセットでは、このレジスタはクリアされません。
 このレジスタのフィールドの詳細は未定です。
 
 .Hardware Status 1 Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |HWARE_STATUS1 |Hardware Status 1 |T.B.D. |R/W
+|bit  |Symbol        |Field             |Description |R/W
+|31:0 |HWARE_STATUS1 |Hardware Status 1 |T.B.D.      |R/W
 |===
 
 .Hardware Status 2 Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |HWARE_STATUS2 |Hardware Status 2 |T.B.D. |R/W
+|bit  |Symbol        |Field             |Description |R/W
+|31:0 |HWARE_STATUS2 |Hardware Status 2 |T.B.D.      |R/W
 |===
 
 ==== System Monitor Interrupt Status Register (Offset 0x0030)
 
-System Monitor Interrupt Status Registerは、System
-Monitorの割り込みステータスレジスタです。
+System Monitor Interrupt Status Registerは、System Monitorの割り込みステータスレジスタです。
 それぞれのビットは"1"をセットすると、割り込みをクリアする事ができます。
 
-SEM Controllerの異常を示すビット (bit 9、bit 10、bit 11)
-は、"1"をセットすると割り込みをクリアする事はできますが、SEM
-Controllerの異常が取り除かれるわけではないため、システムの再起動を行う必要があります。
+SEM Controllerの異常を示すビット (bit 9、bit 10、bit 11)は、"1"をセットすると割り込みをクリアする事はできますが、SEM Controllerの異常が取り除かれるわけではないため、システムの再起動を行う必要があります。
 
 .System Monitor Interrupt Status Registerビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:5 |- |Reserved |Reserved |-
-
-|11 |SEM_HTIMEOUTINT |SEM Heartbeat Timeout Interrupt |SEM Controllerの
-Heartbeat信号が Timeoutしたときにセットされる割り込みビットです。SEM
-Controllerが出力する Heartbeat信号が SEM Heartbeat Timeout
-Registerで設定するクロック数アサートされなかった時セットされます。 |R/WC
-
-|10 |SEM_HALTEDINT |SEM Halted Interrupt |SEM Controllerが Fatal
-Errorにより Haltしたときにセットされる割り込みビットです。SEM Current
-State
-Registerの全ての有効ビットがセットされたとき、この割り込みがセットされます。
-|R/WC
-
-|9 |SEM_UNCORRECTINT |SEM Uncorrectable Interrupt |SEM
-Controllerが訂正不能なエラーを検出したときセットされる割り込みビットです。この割り込みがセットされたとき、SEM
-Controllerは IDLEステートに遷移し
-コンフィギュレーションメモリの監視を停止します。 |R/WC
-
-|8 |SEM_ECORRECTINT |SEM Error Correction Interrupt |SEM
-Controllerがエラーを訂正したときセットされる割り込みビットです。 |R/WC
-
-|7 |PLL_UNLOCKINT |PLL Unlock Interrupt |PLLが異常により
-Unlockしたときセットされる割り込みビットです。 |R/WC
-
-|6:5 |- |Reserved |Reserved |-
-
-|4 |UCLK2_STOPINT |User Clock 2 Stop Interrupt |User Clock
-2が異常により停止したときセットされる割り込みビットです。 |R/WC
-
-|3 |UCLK1_STOPINT |User Clock 1 Stop Interrupt |User Clock
-1が異常により停止したときセットされる割り込みビットです。 |R/WC
-
-|2 |ULPICLK_STOPINT |ULPI Clock Stop Interrupt |ULPI
-Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
-
-|1 |MAXICLK_STOPINT |Main AXI Clock Stop Interrupt |Main AXI
-Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
-
-|0 |SYSCLK_STOPINT |System Clock Stop Interrupt |System
-Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
+|bit  |Symbol           |Field                           |Description |R/W
+|31:5 |-                |Reserved                        |Reserved |-
+|11   |SEM_HTIMEOUTINT  |SEM Heartbeat Timeout Interrupt |SEM Controllerの Heartbeat信号が Timeoutしたときにセットされる割り込みビットです。
+SEM Controllerが出力する Heartbeat信号が SEM Heartbeat Timeout Registerで設定するクロック数アサートされなかった時セットされます。 |R/WC
+|10   |SEM_HALTEDINT    |SEM Halted Interrupt            |SEM Controllerが Fatal Errorにより Haltしたときにセットされる割り込みビットです。
+SEM Current State Registerの全ての有効ビットがセットされたとき、この割り込みがセットされます。|R/WC
+|9    |SEM_UNCORRECTINT |SEM Uncorrectable Interrupt     |SEM Controllerが訂正不能なエラーを検出したときセットされる割り込みビットです。
+この割り込みがセットされたとき、SEM Controllerは IDLEステートに遷移し コンフィギュレーションメモリの監視を停止します。 |R/WC
+|8    |SEM_ECORRECTINT  |SEM Error Correction Interrupt  |SEM Controllerがエラーを訂正したときセットされる割り込みビットです。 |R/WC
+|7    |PLL_UNLOCKINT    |PLL Unlock Interrupt            |PLLが異常により Unlockしたときセットされる割り込みビットです。 |R/WC
+|6:5  |-                |Reserved                        |Reserved |-
+|4    |UCLK2_STOPINT    |User Clock 2 Stop Interrupt     |User Clock 2が異常により停止したときセットされる割り込みビットです。 |R/WC
+|3    |UCLK1_STOPINT    |User Clock 1 Stop Interrupt     |User Clock 1が異常により停止したときセットされる割り込みビットです。 |R/WC
+|2    |ULPICLK_STOPINT  |ULPI Clock Stop Interrupt       |ULPI Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
+|1    |MAXICLK_STOPINT  |Main AXI Clock Stop Interrupt   |Main AXI Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
+|0    |SYSCLK_STOPINT   |System Clock Stop Interrupt     |System Clockが異常により停止したときセットされる割り込みビットです。 |R/WC
 |===
 
 ==== System Monitor Interrupt Enable Register (Offset 0x0034)
 
-System Monitor Interrupt Enable Registerは、System
-Monitorが監視するイベントを割り込み出力信号に通知するか設定するためのレジスタです。
+System Monitor Interrupt Enable Registerは、System Monitorが監視するイベントを割り込み出力信号に通知するか設定するためのレジスタです。
 
 .System Monitor Interrupt Enable Registerビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:5 |- |Reserved |Reserved |-
-
-|11 |SEM_HTIMEOUTENB |SEM Heartbeat Timeout Interrupt Enable
-|SEM_HTIMEOUTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|10 |SEM_HALTEDENB |SEM Halted Interrupt Enable
-|SEM_HALTEDINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|9 |SEM_UNCORRECTENB |SEM Uncorrectable Interrupt Enable
-|SEM_UNCORRECTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|8 |SEM_ECORRECTENB |SEM Error Correction Interrupt Enable
-|SEM_ECORRECTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|7 |PLL_UNLOCKENB |PLL Unlock Interrupt Enable
-|PLL_UNLOCKINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。
-|R/W
-
-|6:5 |- |Reserved |Reserved |-
-
-|4 |UCLK2_STOPENB |User Clock 2 Stop Interrupt Enable
-|UCLK2_STOPINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。
-|R/W
-
-|3 |UCLK1_STOPENB |User Clock 1 Stop Interrupt Enable
-|UCLK1_STOPINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。
-|R/W
-
-|2 |ULPICLK_STOPENB |ULPI Clock Stop Interrupt Enable
-|ULPICLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|1 |MAXICLK_STOPENB |Main AXI Clock Stop Interrupt Enable
-|MAXICLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|0 |SYSCLK_STOPENB |System Clock Stop Interrupt Enable
-|SYSCLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。
-|R/W
+|bit  |Symbol           |Field                                  |Description                                                                          |R/W
+|31:5 |-                |Reserved                               |Reserved                                                                             |-
+|11   |SEM_HTIMEOUTENB  |SEM Heartbeat Timeout Interrupt Enable |SEM_HTIMEOUTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。  |R/W
+|10   |SEM_HALTEDENB    |SEM Halted Interrupt Enable            |SEM_HALTEDINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。    |R/W
+|9    |SEM_UNCORRECTENB |SEM Uncorrectable Interrupt Enable     |SEM_UNCORRECTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。 |R/W
+|8    |SEM_ECORRECTENB  |SEM Error Correction Interrupt Enable  |SEM_ECORRECTINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。  |R/W
+|7    |PLL_UNLOCKENB    |PLL Unlock Interrupt Enable            |PLL_UNLOCKINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。      |R/W
+|6:5  |-                |Reserved                               |Reserved                                                                             |-
+|4    |UCLK2_STOPENB    |User Clock 2 Stop Interrupt Enable     |UCLK2_STOPINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。      |R/W
+|3    |UCLK1_STOPENB    |User Clock 1 Stop Interrupt Enable     |UCLK1_STOPINTイベントが発生した時、割り込み信号を発生させるかどうか設定します。      |R/W
+|2    |ULPICLK_STOPENB  |ULPI Clock Stop Interrupt Enable       |ULPICLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。  |R/W
+|1    |MAXICLK_STOPENB  |Main AXI Clock Stop Interrupt Enable   |MAXICLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。  |R/W
+|0    |SYSCLK_STOPENB   |System Clock Stop Interrupt Enable     |SYSCLK_STOPINTイベントが発生した時、割り込み信号を発生させるかどうかを設定します。   |R/W
 |===
 
 ==== SEM Controller State Register (0ffset 0x0040)
@@ -827,20 +504,17 @@ Currentステート、Previousステートの全てのビットが Highにセッ
 |17    |SEM_PREOBSERVE   |SEM Previous Oveservation State   |SEM Controllerの前のステートが監視ステートだった事を示します。       |RO
 |16    |SEM_PREINIT      |SEM Previous Initilize State      |SEM Controllerの前のステートが初期化ステートだった事を示します。     |RO
 |15:5  |-                |Reserved                          |Reserved                                                             |-
-|4     |SEM_CURINJECT    |SEM Current Error Injection State |
-SEM Controllerがエラー挿入ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerはエラー挿入ステートです。 |RO
+|4     |SEM_CURINJECT    |SEM Current Error Injection State |SEM Controllerがエラー挿入ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerはエラー挿入ステートです。 |RO
 |3     |SEM_CURCLASSIFIC |SEM Current Classification State  |SEM Controllerが分類ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerは分類ステートです。 |RO
 |2     |SEM_CURCORRECT   |SEM Current Correction State      |SEM Controllerが訂正ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerは訂正ステートです。 |RO
 |1     |SEM_CUROBSERVE   |SEM Current Oveservation State    |SEM Controllerが監視ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerは監視ステートです。 |RO
-|0     |SEM_CURINIT      |SEM Current Initilize State       |
-SEM Controllerが初期化ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerは初期化ステートです。
+|0     |SEM_CURINIT      |SEM Current Initilize State       |SEM Controllerが初期化ステートである事を示します。このビットのみが Highにセットされているとき、SEM Controllerは初期化ステートです。
 このビットは FPGAが動作を開始した後に 1度だけ発生する初期化の間アクティブになります。 |RO
 |===
 
 ==== SEM Error Correction Count Register (Offset 0x0044)
 
-SEM Error Correction Count Registerは、SEM
-Controllerが行ったエラー訂正数をカウントします。
+SEM Error Correction Count Registerは、SEM Controllerが行ったエラー訂正数をカウントします。
 
 このレジスタはPower On Resetのみでリセットされ、システムリセットでは初期化が行われません。
 そのため、Bootloaderから Flight Softwareに切り替わる時にはリセットされず、SEM Controllerのエラーは累積のエラーを示します。
@@ -855,10 +529,8 @@ Controllerが行ったエラー訂正数をカウントします。
 
 ==== SEM Heartbeat Timeout Register (Offset 0x0048)
 
-SEM Heartbeat Timeout Registeは SEM Controllerが出力する Heartbeat信号の
-Timeout時間を設定するレジスタです。 AMD (旧 Xilinx) の SEM Controller
-(v4.1)では、Heartbeat信号のアサート間隔は
-150クロックと規定されており、本レジスタの値は修正する必要はありません。
+SEM Heartbeat Timeout Registeは SEM Controllerが出力する Heartbeat信号の Timeout時間を設定するレジスタです。
+AMD (旧 Xilinx) の SEM Controller (v4.1)では、Heartbeat信号のアサート間隔は 150クロックと規定されており、本レジスタの値は修正する必要はありません。
 
 このレジスタはPower On Resetのみでリセットされ、システムリセットでは初期化が行われません。
 そのため、Bootloaderから Flight Softwareに切り替わる時にはリセットされません。
@@ -866,30 +538,21 @@ Timeout時間を設定するレジスタです。 AMD (旧 Xilinx) の SEM Contr
 .SEM Heartbeat Timeout Registerビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |HTIMEOUT |Heartbeat Timeout Value |SEM Controllerが出力する
-Heartbeat信号の受信Timeout時間を設定します。SEM
-Controllerのステートが、監視ステートのとき
-このレジスタに設定されるカウント値まで
-Heartbeat信号がアサートされないとき、SEM Heartbeat
-Timeout割り込みを発生させます。 |R/W
+|bit  |Symbol   |Field                   |Description |R/W
+|31:8 |-        |Reserved                |Reserved    |-
+|7:0  |HTIMEOUT |Heartbeat Timeout Value |SEM Controllerが出力する Heartbeat信号の受信Timeout時間を設定します。
+SEM Controllerのステートが、監視ステートのとき このレジスタに設定されるカウント値まで Heartbeat信号がアサートされないとき、SEM Heartbeat Timeout割り込みを発生させます。 |R/W
 |===
 
 ==== SEM Error Injection Command Register 1/2 (Offset 0x0050/0x0054)
 
-SEM Error Injection Command Register は、SEM Controller
-のエラー挿入機能を使用するためのレジスタです。 このレジスタを使用し、SEM
-Controllerのエラー挿入インターフェースにコマンドを入力する事により、エラー挿入機能を使用する事ができます。
+SEM Error Injection Command Register は、SEM Controllerのエラー挿入機能を使用するためのレジスタです。
+このレジスタを使用し、SEM Controllerのエラー挿入インターフェースにコマンドを入力する事により、エラー挿入機能を使用する事ができます。
 
-このレジスタは試験専用レジスタであり、FPGA
-インプリ時のコンフィギュレーションにより、無効化する事ができます。
+このレジスタは試験専用レジスタであり、FPGAインプリ時のコンフィギュレーションにより、無効化する事ができます。
 
-SEM Controller へのコマンド送信は、SEM Error Injection Command Register
-2 への書き込みをきっかけに行われます。 そのため、SEM Error Injection
-Command Register 1 への書き込みは、必ず SEM Error Injection Command
-Register 2 の書き込み前に行ってください。
+SEM Controller へのコマンド送信は、SEM Error Injection Command Register 2 への書き込みをきっかけに行われます。
+そのため、SEM Error Injection Command Register 1 への書き込みは、必ず SEM Error Injection Command Register 2 の書き込み前に行ってください。
 
 このレジスタはPower On Resetのみでリセットされ、システムリセットでは初期化が行われません。
 そのため、Bootloaderから Flight Softwareに切り替わる時にはリセットされません。
@@ -897,203 +560,113 @@ Register 2 の書き込み前に行ってください。
 .SEM Error Injection Command Register 1ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:0 |EINJECT1 |Error Injection 1 |SEM
-Controllerのエラー挿入インターフェースにコマンドを入力するためのフィールドです。このフィールドにはエラー挿入コマンドの
-Bit 31:0 を設定します。 |R/W
+|bit  |Symbol   |Field             |Description                                                                                                                                        |R/W
+|31:0 |EINJECT1 |Error Injection 1 |SEM Controllerのエラー挿入インターフェースにコマンドを入力するためのフィールドです。このフィールドにはエラー挿入コマンドの Bit 31:0 を設定します。 |R/W
 |===
 
 .SEM Error Injection Command Register 2ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |EINJECT2 |Error Injection 2 |SEM
-Controllerのエラー挿入インターフェースにコマンドを入力するためのフィールドです。このフィールドにはエラー挿入コマンドの
-Bit 39:32 を設定します。このフィールドをセットすると SEM Error Injection
-1 の設定値と合わせ SEM Controllerにエラーコマンドが送信されます。 |R/W
+|bit  |Symbol   |Field             |Description |R/W
+|31:8 |-        |Reserved          |Reserved    |-
+|7:0  |EINJECT2 |Error Injection 2 |SEM Controllerのエラー挿入インターフェースにコマンドを入力するためのフィールドです。
+このフィールドにはエラー挿入コマンドの Bit 39:32 を設定します。
+このフィールドをセットすると SEM Error Injection 1 の設定値と合わせ SEM Controllerにエラーコマンドが送信されます。 |R/W
 |===
 
 ==== XADC Register Window (Offset 0x1000-1FFF)
 
-XADC Register Fieldは、SC-OBC-A1 FPGAに搭載されている AMD (旧 Xilinx) の
-ADCモジュールとのアクセスを行うための領域です。
+XADC Register Fieldは、SC-OBC-A1 FPGAに搭載されている AMD (旧 Xilinx) の ADCモジュールとのアクセスを行うための領域です。
 
 XADCは AMD (旧 Xilinx) 7シリーズ FPGAに搭載される ADCモジュールです。
-XADCには 12 bit、毎秒 1 Mサンプルの
-ADCとオンチップセンサーが含まれています。 SC-OBC-A1
-FPGAでは、XADCのレジスタを読み出す事により、FPGAのダイの温度と入力電源の監視を行う事ができます。
+XADCには 12 bit、毎秒 1 Mサンプルの ADCとオンチップセンサーが含まれています。
+SC-OBC-A1 FPGAでは、XADCのレジスタを読み出す事により、FPGAのダイの温度と入力電源の監視を行う事ができます。
 
-XADCの詳細は AMD (旧 Xilinx) のドキュメント (UG480: 7シリーズ FPGAおよび
-Zynq-7000 All Programmable SoC XADCデュアル 12ビット 1 MPSPS
-アナログ-デジタルコンバーター ユーザーズガイド)を参照してください。
+XADCの詳細は AMD (旧 Xilinx) のドキュメント (UG480: 7シリーズ FPGAおよび Zynq-7000 All Programmable SoC XADCデュアル 12ビット 1 MPSPSアナログ-デジタルコンバーター ユーザーズガイド)を参照してください。
 
-XADCのレジスタにアクセスするためには、ベースアドレスを 0x4F041000とし
-Bit 11:4に 対象となるXADCのレジスタアドレスを設定する事で行えます。
+XADCのレジスタにアクセスするためには、ベースアドレスを 0x4F041000とし Bit 11:4に 対象となるXADCのレジスタアドレスを設定する事で行えます。
 Status Registerにアクセスするためのレジスタアドレスを以下に示します。
 
 [cols=",,",options="header",]
 |===
-|Offset |Name |Description
-|0x1000 |Temperature Status
-|オンチップ温度センサーの測定結果が格納されます。Bit 15:4の 12
-Bitが温度センサーの伝達関数に対応します。
-
-|0x1010 |VCCINT Status
-|オンチップVCCINT電圧モニターの測定結果が格納されます。Bit 15:4の 12
-Bitが電圧センサーの伝達関数に対応します。
-
-|0x1020 |VCCAUX Status
-|オンチップVCCAUX電圧モニターの測定結果が格納されます。Bit 15:4の 12
-Bitが電圧センサーの伝達関数に対応します。
-
-|0x1060 |VCCBRAM Status
-|オンチップVCCBRAM電圧モニターの測定結果が格納されます。Bit 15:4の 12
-Bitが電圧センサーの伝達関数に対応します。
-
-|0x1200 |Max Temperature |電源投入または最後に
-XADCをリセットしてから記録された最大温度測定値が格納されます。
-
-|0x1210 |Max VCCINT |電源投入または最後に
-XADCをリセットしてから記録された最大VCCINT測定値が格納されます。
-
-|0x1220 |Max VCCAUX |電源投入または最後に
-XADCをリセットしてから記録された最大VCCAUX測定値が格納されます。
-
-|0x1230 |Max VCCBRAM |電源投入または最後に
-XADCをリセットしてから記録された最大VCCBRAM測定値が格納されます。
-
-|0x1240 |Min Temperature |電源投入または最後に
-XADCをリセットしてから記録された最小温度測定値が格納されます。
-
-|0x1250 |Min VCCINT |電源投入または最後に
-XADCをリセットしてから記録された最小VCCINT測定値が格納されます。
-
-|0x1260 |Min VCCAUX |電源投入または最後に
-XADCをリセットしてから記録された最小VCCAUX測定値が格納されます。
-
-|0x1270 |Min VCCBRAM |電源投入または最後に
-XADCをリセットしてから記録された最小VCCBRAM測定値が格納されます。
+|Offset |Name               |Description
+|0x1000 |Temperature Status |オンチップ温度センサーの測定結果が格納されます。Bit 15:4の 12 Bitが温度センサーの伝達関数に対応します。
+|0x1010 |VCCINT Status      |オンチップVCCINT電圧モニターの測定結果が格納されます。Bit 15:4の 12 Bitが電圧センサーの伝達関数に対応します。
+|0x1020 |VCCAUX Status      |オンチップVCCAUX電圧モニターの測定結果が格納されます。Bit 15:4の 12 Bitが電圧センサーの伝達関数に対応します。
+|0x1060 |VCCBRAM Status     |オンチップVCCBRAM電圧モニターの測定結果が格納されます。Bit 15:4の 12 Bitが電圧センサーの伝達関数に対応します。
+|0x1200 |Max Temperature    |電源投入または最後に XADCをリセットしてから記録された最大温度測定値が格納されます。
+|0x1210 |Max VCCINT         |電源投入または最後に XADCをリセットしてから記録された最大VCCINT測定値が格納されます。
+|0x1220 |Max VCCAUX         |電源投入または最後に XADCをリセットしてから記録された最大VCCAUX測定値が格納されます。
+|0x1230 |Max VCCBRAM        |電源投入または最後に XADCをリセットしてから記録された最大VCCBRAM測定値が格納されます。
+|0x1240 |Min Temperature    |電源投入または最後に XADCをリセットしてから記録された最小温度測定値が格納されます。
+|0x1250 |Min VCCINT         |電源投入または最後に XADCをリセットしてから記録された最小VCCINT測定値が格納されます。
+|0x1260 |Min VCCAUX         |電源投入または最後に XADCをリセットしてから記録された最小VCCAUX測定値が格納されます。
+|0x1270 |Min VCCBRAM        |電源投入または最後に XADCをリセットしてから記録された最小VCCBRAM測定値が格納されます。
 |===
 
-System Monitorの XADC Register
-Windowからは、XADCのすべてのレジスタ領域にアクセスする事ができますが、アラーム機能は現状実装されておりません。
+System Monitorの XADC Register Windowからは、XADCのすべてのレジスタ領域にアクセスする事ができますが、アラーム機能は現状実装されておりません。
 
 ==== BHM Initialization Access Control Register (Offset 0x2000)
 
-BHM Initialization Access Control Registerは、OBC
-Moduleに実装するセンサーの初期化に関する制御を行うためのレジスタです。
-Board Health
-Monitorは、このレジスタを制御することによって、センサーに対し初期化のためのレジスタアクセスを実行します。
+BHM Initialization Access Control Registerは、OBC Moduleに実装するセンサーの初期化に関する制御を行うためのレジスタです。
+Board Health Monitorは、このレジスタを制御することによって、センサーに対し初期化のためのレジスタアクセスを実行します。
 
-Initialization Requestビットを "1"にセットすると、Initialization
-Enableビットが "1"にセットされているセンサーに初期化を行います。
-Initialization RequestビットとInitialization
-Enableビットは、同時にセットすることができます。
+Initialization Requestビットを "1"にセットすると、Initialization Enableビットが "1"にセットされているセンサーに初期化を行います。
+Initialization RequestビットとInitialization Enableビットは、同時にセットすることができます。
 
 センサーに設定する初期値は、RTL設計時にVerilogパラメータで指定する事ができます。
 
 .BHM Initialization Access Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:17 |- |Reserved |Reserved |-
-
-|16 |BHM_INITREQ |Initialization Request |OBC
-Moduleに実装するセンサーの初期化を開始するためのビットです。このビットに"1"をセットすると、初期化を開始します。Initialization
-Enableがセットされている全てのセンサーの初期化が完了すると、このビットは自動的に
-"0"にクリアされます。 |R/W
-
-|15:5 |- |Reserved |Reserved |-
-
-|4 |BHM_TEMP3INITEN |Temperature Sensor 3 Initialization Enable
-|Temperature Sensor 3 の初期化を有効化するためのビットです。0:
-Temperature Sensor 3 Initialization Disable 1: Temperature Sensor3
-Initialization Enable |R/W
-
-|3 |BHM_TEMP2INITEN |Temperature Sensor 2 Initialization Enable
-|Temperature Sensor 2 の初期化を有効化するためのビットです。0:
-Temperature Sensor 2 Initialization Disable 1: Temperature Sensor2
-Initialization Enable |R/W
-
-|2 |BHM_TEMP1INITEN |Temperature Sensor 1 Initialization Enable
-|Temperature Sensor 1 の初期化を有効化するためのビットです。0:
-Temperature Sensor 1 Initialization Disable 1: Temperature Sensor1
-Initialization Enable |R/W
-
-|1 |BHM_CVM2INITEN |Current Voltage Monitor 2 Initialization Enable
-|Current Voltage Monitor 2 の初期化を有効化するためのビットです。0:
-Current Voltage Monitor 2 Initialization Disable 1: Current Voltage
-Monitor2 Initialization Enable |R/W
-
-|0 |BHM_CVM1INITEN |Current Voltage Monitor 1 Initialization Enable
-|Current Voltage Monitor 1 の初期化を有効化するためのビットです。0:
-Current Voltage Monitor 1 Initialization Disable 1: Current Voltage
-Monitor1 Initialization Enable |R/W
+|bit   |Symbol          |Field                                      |Description |R/W
+|31:17 |-               |Reserved                                   |Reserved |-
+|16    |BHM_INITREQ     |Initialization Request                     |OBC Moduleに実装するセンサーの初期化を開始するためのビットです。
+このビットに"1"をセットすると、初期化を開始します。Initialization Enableがセットされている全てのセンサーの初期化が完了すると、このビットは自動的に "0"にクリアされます。 |R/W
+|15:5  |-               |Reserved                                   |Reserved |-
+|4     |BHM_TEMP3INITEN |Temperature Sensor 3 Initialization Enable |Temperature Sensor 3 の初期化を有効化するためのビットです。 +
+0: Temperature Sensor 3 Initialization Disable +
+1: Temperature Sensor3 Initialization Enable |R/W
+|3     |BHM_TEMP2INITEN |Temperature Sensor 2 Initialization Enable |Temperature Sensor 2 の初期化を有効化するためのビットです。 +
+0: Temperature Sensor 2 Initialization Disable +
+1: Temperature Sensor2 Initialization Enable |R/W
+|2     |BHM_TEMP1INITEN |Temperature Sensor 1 Initialization Enable |Temperature Sensor 1 の初期化を有効化するためのビットです。 +
+0: Temperature Sensor 1 Initialization Disable +
+1: Temperature Sensor1 Initialization Enable |R/W
+|1     |BHM_CVM2INITEN  |Current Voltage Monitor 2 Initialization Enable |Current Voltage Monitor 2 の初期化を有効化するためのビットです。 +
+0: Current Voltage Monitor 2 Initialization Disable +
+1: Current Voltage Monitor2 Initialization Enable |R/W
+|0     |BHM_CVM1INITEN  |Current Voltage Monitor 1 Initialization Enable |Current Voltage Monitor 1 の初期化を有効化するためのビットです。 +
+0: Current Voltage Monitor 1 Initialization Disable  +
+1: Current Voltage Monitor1 Initialization Enable |R/W
 |===
 
 ==== BHM Access Control Register (Offset 0x2004)
 
-BHM Access Control Registerは、OBC
-Moduleに実装するセンサーからのセンサーデータの自動読み出しに関する設定を行うためのレジスタです。
+BHM Access Control Registerは、OBC Moduleに実装するセンサーからのセンサーデータの自動読み出しに関する設定を行うためのレジスタです。
 
-対象のセンサーの Monitor Enableビットを
-"1"にセットしておくと、GPTMRモジュールに実装する Hardware Schedulerから
-タイミングパルスを受信するたびに、対応するセンサーからデータを読み出します。
+対象のセンサーの Monitor Enableビットを "1"にセットしておくと、GPTMRモジュールに実装する Hardware Schedulerから タイミングパルスを受信するたびに、対応するセンサーからデータを読み出します。
 
 .BHM Access Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:5 |- |Reserved |Reserved |-
-
-|4 |BHM_TEMP3MONIEN |Temperature Sensor 3 Monitor Enable |Temperature
-Sensor 3からセンサーデータを読み出すための設定を行うビットです。
-このビットが "1"にセットされている時に Hardware
-Schedulerからタイミングパルスを受信すると、Temperature Sensor
-3から温度データを読み出します。BHM_TEMP3I2CERR
-割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 0:
-Temperature Sensor 3 Monitor Disable 1: Temperature Sensor 3 Monitoring
-Enable |R/W
-
-|3 |BHM_TEMP2MONIEN |Temperature Sensor 2 Monitor Enable |Temperature
-Sensor 2からセンサーデータを読み出すための設定を行うビットです。
-このビットが "1"にセットされている時に Hardware
-Schedulerからタイミングパルスを受信すると、Temperature Sensor
-2から温度データを読み出します。BHM_TEMP2I2CERR
-割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 0:
-Temperature Sensor 2 Monitor Disable 1: Temperature Sensor 2 Monitoring
-Enable |R/W
-
-|2 |BHM_TEMP1MONIEN |Temperature Sensor 1 Monitor Enable |Temperature
-Sensor 1からセンサーデータを読み出すための設定を行うビットです。
-このビットが "1"にセットされている時に Hardware
-Schedulerからタイミングパルスを受信すると、Temperature Sensor
-1から温度データを読み出します。BHM_TEMP1I2CERR
-割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 0:
-Temperature Sensor 1 Monitor Disable 1: Temperature Sensor 1 Monitoring
-Enable |R/W
-
-|1 |BHM_CVM2MONIEN |Current Voltage Monitor 2 Monitor Enable |Current
-Voltage Monitor
-2からセンサーデータを読み出すための設定を行うビットです。このビットが
-"1"にセットされている時に Hardware
-Schedulerからタイミングパルスを受信すると、Current Voltage Monitor
-2からシャント電圧とバス電圧データを読み出します。BHM_CVM2I2CERR
-割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 0:
-Current Voltage Monitor 2 Monitor Disable 1: Current Voltage Monitor2
-Monitoring Enable |R/W
-
-|0 |BHM_CVM1MONIEN |Current Voltage Monitor 1 Monitor Enable |Current
-Voltage Monitor
-1からセンサーデータの読み出すための設定を行うビットです。このビットが
-"1"にセットされている時に Hardware
-Schedulerからタイミングパルスを受信すると、Current Voltage Monitor
-1からシャント電圧とバス電圧データを読み出します。BHM_CVM1I2CERR
-割り込みが発生した場合、このビットは自動的に "0"にクリアされます。0:
-Current Voltage Monitor 1 Monitor Disable 1: Current Voltage Monitor1
-Monitoring Enable |R/W
+|bit  |Symbol          |Field                                   |Description |R/W
+|31:5 |-               |Reserved                                |Reserved |-
+|4    |BHM_TEMP3MONIEN |Temperature Sensor 3 Monitor Enable     |Temperature Sensor 3からセンサーデータを読み出すための設定を行うビットです。 このビットが "1"にセットされている時に Hardware Schedulerからタイミングパルスを受信すると、Temperature Sensor 3から温度データを読み出します。BHM_TEMP3I2CERR 割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 +
+0: Temperature Sensor 3 Monitor Disable +
+1: Temperature Sensor 3 Monitoring Enable |R/W
+|3    |BHM_TEMP2MONIEN |Temperature Sensor 2 Monitor Enable     |Temperature Sensor 2からセンサーデータを読み出すための設定を行うビットです。 このビットが "1"にセットされている時に  Schedulerからタイミングパルスを受信すると、Temperature Sensor 2から温度データを読み出します。BHM_TEMP2I2CERR 割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 +
+0: Temperature Sensor 2 Monitor Disable +
+1: Temperature Sensor 2 Monitoring Enable |R/W
+|2    |BHM_TEMP1MONIEN |Temperature Sensor 1 Monitor Enable     |Temperature Sensor 1からセンサーデータを読み出すための設定を行うビットです。このビットが "1"にセットされている時に Hardware Schedulerからタイミングパルスを受信すると、Temperature Sensor 1から温度データを読み出します。BHM_TEMP1I2CERR 割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 +
+0: Temperature Sensor 1 Monitor Disable +
+1: Temperature Sensor 1 Monitoring Enable |R/W
+|1    |BHM_CVM2MONIEN |Current Voltage Monitor 2 Monitor Enable |Current Voltage Monitor 2からセンサーデータを読み出すための設定を行うビットです。このビットが "1"にセットされている時に Hardware Schedulerからタイミングパルスを受信すると、Current Voltage Monitor 2からシャント電圧とバス電圧データを読み出します。BHM_CVM2I2CERR 割り込みが発生した場合、このビットは自動的に"0"にクリアされます。 +
+0: Current Voltage Monitor 2 Monitor Disable +
+1: Current Voltage Monitor 2 Monitoring Enable |R/W
+|0    |BHM_CVM1MONIEN |Current Voltage Monitor 1 Monitor Enable |Current Voltage Monitor 1からセンサーデータの読み出すための設定を行うビットです。このビットが "1"にセットされている時に Hardware Schedulerからタイミングパルスを受信すると、Current Voltage Monitor 1からシャント電圧とバス電圧データを読み出します。BHM_CVM1I2CERR 割り込みが発生した場合、このビットは自動的に "0"にクリアされます。 +
+0: Current Voltage Monitor 1 Monitor Disable +
+1: Current Voltage Monitor 1 Monitoring Enable |R/W
 |===
 
 ==== BHM Interrupt Status Register (Offset: 0x2010)
@@ -1105,151 +678,47 @@ Monitorの割り込みステータスレジスタです。 それぞれのビッ
 .BHM Interrupt Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:19 |- |Reserved |Reserved |-
-
-|18 |BHM_TEMPALERT |Temperature Sensor Alert Detect |温度センサーから
-Alert信号を受信したことを示すビットです。OBC
-Module上に実装される、いずれかの温度センサーが
-Alert信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
-
-|17 |BHM_CVMWARN |Current Voltage Monitor Warning Alert Detect |Current
-Voltage Monitorから Warning Alert信号を受信したことを示すビットです。OBC
-Module上に実装される、いずれかの Current Voltage Monitorが
-Warning信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
-
-|16 |BHM_CVMCRIT |Current Voltage Monitor Critical Alert Detect
-|Current Voltage Monitorから Critical
-Alert信号を受信したことを示すビットです。OBC
-Module上に実装される、いずれかの Current Voltage Monitorが
-Critical信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
-
-|15:14 |- |Reserved |Reserved |-
-
-|13 |BHM_SWI2CERR |Software I2C Error
-|ソフトウェア指示によるセンサーへのアクセスにおいてエラーが発生したことを示すビットです。BHM
-Retry Count Setting
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|12 |BHM_TEMP3I2CERR |Temperature Sensor 3 I2C Error |Temperature
-Sensor 3
-へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM
-Retry Count Setting
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|11 |BHM_TEMP2I2CERR |Temperature Sensor 2 I2C Error |Temperature
-Sensor 2
-へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM
-Retry Count Setting
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|10 |BHM_TEMP1I2CERR |Temperature Sensor 1 I2C Error |Temperature
-Sensor 1
-へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM
-Retry Count Setting
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|9 |BHM_CVM2I2CERR |Current Voltage Monitor2 I2C Error |Current Voltage
-Monitor 2
-へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM
-Retry Count
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|8 |BHM_CVM1I2CERR |Current Voltage Monitor1 I2C Error |Current Voltage
-Monitor 1
-へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM
-Retry Count
-Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが
-"1"にセットされます。 |R/WC
-
-|7:2 |- |Reserved |Reserved |-
-
-|1 |BHM_SWACCEND |Software Access End
-|ソフトウェア指示によるセンサーへの
-I2Cアクセスが完了した事を示すビットです。センサーのレジスタへのデータ書き込み
-または、読み出しが完了した時、本ビットが "1"にセットされます。 |R/WC
-
-|0 |BHM_INITACCEND |Initialization Access End
-|センサーの初期化が完了した事を示すビットです。BHM Initialization Access
-Control RegisterのInitialization Requestをセットした後に、Initialization
-Enableビットがセットされている全てのセンサーの初期化が完了した時、本ビットが
-"1"にセットされます。 |R/WC
+|bit   |Symbol          |Field                                         |Description |R/W
+|31:19 |-               |Reserved                                      |Reserved |-
+|18    |BHM_TEMPALERT   |Temperature Sensor Alert Detect               |温度センサーから Alert信号を受信したことを示すビットです。OBC Module上に実装される、いずれかの温度センサーが Alert信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
+|17    |BHM_CVMWARN     |Current Voltage Monitor Warning Alert Detect  |Current Voltage Monitorから Warning Alert信号を受信したことを示すビットです。OBC Module上に実装される、いずれかの Current Voltage Monitorが Warning信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
+|16    |BHM_CVMCRIT     |Current Voltage Monitor Critical Alert Detect |Current Voltage Monitorから Critical Alert信号を受信したことを示すビットです。OBC Module上に実装される、いずれかの Current Voltage Monitorが Critical信号をアサートした時、本ビットが"1"にセットされます。 |R/WC
+|15:14 |- |Reserved     |Reserved                                      |-
+|13    |BHM_SWI2CERR    |Software I2C Error                            |ソフトウェア指示によるセンサーへのアクセスにおいてエラーが発生したことを示すビットです。BHM Retry Count Setting Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|12    |BHM_TEMP3I2CERR |Temperature Sensor 3 I2C Error                |Temperature Sensor 3 へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM Retry Count Setting Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|11    |BHM_TEMP2I2CERR |Temperature Sensor 2 I2C Error                |Temperature Sensor 2 へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM Retry Count Setting Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|10    |BHM_TEMP1I2CERR |Temperature Sensor 1 I2C Error                |Temperature Sensor 1 へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM Retry Count Setting Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|9     |BHM_CVM2I2CERR  |Current Voltage Monitor2 I2C Error            |Current Voltage Monitor 2 へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM Retry Count Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|8     |BHM_CVM1I2CERR  |Current Voltage Monitor1 I2C Error            |Current Voltage Monitor 1 へのアクセスにおいてエラーが発生した事を示すビットです。センサーの初期化とデータ読み出しのどちらのエラーも本ビットに通知されます。BHM Retry Count Registerに設定されているリトライ回数を超えるエラーが連続で発生した場合に、本ビットが "1"にセットされます。 |R/WC
+|7:2   |-               |Reserved                                      |Reserved |-
+|1     |BHM_SWACCEND    |Software Access End                           |ソフトウェア指示によるセンサーへの I2Cアクセスが完了した事を示すビットです。センサーのレジスタへのデータ書き込み または、読み出しが完了した時、本ビットが "1"にセットされます。 |R/WC
+|0     |BHM_INITACCEND  |Initialization Access End                     |センサーの初期化が完了した事を示すビットです。BHM Initialization Access Control RegisterのInitialization Requestをセットした後に、Initialization Enableビットがセットされている全てのセンサーの初期化が完了した時、本ビットが "1"にセットされます。 |R/WC
 |===
 
 ==== BHM Interrupt Enable Register (Offset: 0x2014)
 
-BHM Interrupt Enable Registerは、Board Health
-Monitorの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
+BHM Interrupt Enable Registerは、Board Health Monitorの割り込みイベントを割り込み信号に通知する設定を行うためのレジスタです。
 
-本レジスタのビットが "1"にセットされている時、その割り込み要因に対応する
-Interrupt Status Registerのビットが
-"1"にセットされると、割り込み信号がアサートします。
+本レジスタのビットが "1"にセットされている時、その割り込み要因に対応する Interrupt Status Registerのビットが "1"にセットされると、割り込み信号がアサートします。
 
 .Board Health Interrupt Enable Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:19 |- |Reserved |Reserved |-
-
-|18 |BHM_TEMPALERTENB |Temperature Sensor Alert Detect Enable
-|BHM_TEMPALERTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|17 |BHM_CVMWARNENB |Current Voltage Monitor Warning Alert Detect
-Enable
-|BHM_CVMWARNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|16 |BHM_CVMCRITENB |Current Voltage Monitor Critical Alert Detect
-Enable
-|BHM_CVMCRITイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|15:14 |- |Reserved |Reserved |-
-
-|13 |BHM_SWI2CERRENB |Software I2C Access Error Enable
-|BHM_SWI2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|12 |BHM_TEMP3I2CERRENB |Temperature Sensor3 Auto I2C Access Error
-Enable
-|BHM_TEMP3I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|11 |BHM_TEMP2I2CERRENB |Temperature Sensor2 Auto I2C Access Error
-Enable
-|BHM_TEMP2I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|10 |BHM_TEMP1I2CERRENB |Temperature Sensor1 Auto I2C Access Error
-Enable
-|BHM_TEMP1I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|9 |BHM_CVM2I2CERRENB |Current Voltage Monitor2 Auto I2C Access Error
-Enable
-|BHM_CVM2I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|8 |BHM_CVM1I2CERRENB |Current Voltage Monitor1 Auto I2C Access Error
-Enable
-|BHM_CVM1I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|7:2 |- |Reserved |Reserved |-
-
-|1 |BHM_SWACCENDENB |Software Access End Enable
-|BHM_SWACCENDイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
-
-|0 |BHM_INITACCENDENB |Initialization Access End Enable
-|BHM_INITACCENDイベントが発生した時に割り込み信号を発生させるかどうかを設定します。
-|R/W
+|bit   |Symbol             |Field                                                 |Description                                                                        |R/W
+|31:19 |-                  |Reserved                                              |Reserved                                                                           |-
+|18    |BHM_TEMPALERTENB   |Temperature Sensor Alert Detect Enable                |BHM_TEMPALERTイベントが発生した時に割り込み信号を発生させるかどうかを設定します。  |R/W
+|17    |BHM_CVMWARNENB     |Current Voltage Monitor Warning Alert Detect Enable   |BHM_CVMWARNイベントが発生した時に割り込み信号を発生させるかどうかを設定します。    |R/W
+|16    |BHM_CVMCRITENB     |Current Voltage Monitor Critical Alert Detect Enable  |BHM_CVMCRITイベントが発生した時に割り込み信号を発生させるかどうかを設定します。    |R/W
+|15:14 |-                  |Reserved                                              |Reserved                                                                           |-
+|13    |BHM_SWI2CERRENB    |Software I2C Access Error Enable                      |BHM_SWI2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。   |R/W
+|12    |BHM_TEMP3I2CERRENB |Temperature Sensor3 Auto I2C Access Error Enable      |BHM_TEMP3I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|11    |BHM_TEMP2I2CERRENB |Temperature Sensor2 Auto I2C Access Error Enable      |BHM_TEMP2I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|10    |BHM_TEMP1I2CERRENB |Temperature Sensor1 Auto I2C Access Error Enable      |BHM_TEMP1I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。|R/W
+|9     |BHM_CVM2I2CERRENB  |Current Voltage Monitor2 Auto I2C Access Error Enable |BHM_CVM2I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|8     |BHM_CVM1I2CERRENB  |Current Voltage Monitor1 Auto I2C Access Error Enable |BHM_CVM1I2CERRイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
+|7:2   |-                  |Reserved                                              |Reserved                                                                           |-
+|1     |BHM_SWACCENDENB    |Software Access End Enable                            |BHM_SWACCENDイベントが発生した時に割り込み信号を発生させるかどうかを設定します。   |R/W
+|0     |BHM_INITACCENDENB  |Initialization Access End Enable                      |BHM_INITACCENDイベントが発生した時に割り込み信号を発生させるかどうかを設定します。 |R/W
 |===
 
 ==== BHM VDD_1V0 Shunt Voltage Monitor Register (Offset 0x2020)
@@ -1257,333 +726,226 @@ Enable
 BHM VDD_1V0 Shunt Voltage Monitor Registerは、VDD_1V0 電源ドメインの
 Shunt Voltageを読み出すためのレジスタです。
 
-BHM Shunt Voltage Monitor Registerに格納されるデータは、Current Voltage
-Monitor INA3221-Q1の Shunt Voltage Registerからの取得データです。 Shunt
-Voltageの実効データは Bit 15:3に格納されます。 Bit 2:0は ALL
-0が格納されます。
+BHM Shunt Voltage Monitor Registerに格納されるデータは、Current Voltage Monitor INA3221-Q1の Shunt Voltage Registerからの取得データです。
+Shunt Voltageの実効データは Bit 15:3に格納されます。 Bit 2:0は ALL 0が格納されます。
 
 .BHM VDD_1V0 Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_1V0SNTVNUPD |VDD_1V0 Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_1V0SNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_1V0SNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_1V0SNTV |VDD_1V0 Shunt Voltage Monitor |VDD_1V0
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                             |Description |R/W
+|31    |BHM_1V0SNTVNUPD |VDD_1V0 Shunt Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが"1"にセットされている時、BHM_1V0SNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは"0"にクリアされ、BHM_1V0SNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは"1"を示します。 |RO
+|30:16 |-               |Reserved                          |Reserved |-
+|15:0  |BHM_1V0SNTV     |VDD_1V0 Shunt Voltage Monitor     |VDD_1V0電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_1V0 Bus Voltage Monitor Register (Offset 0x2024)
 
-BHM VDD_1V0 Bus Voltage Monitor Registerは、VDD_1V0 電源ドメインの Bus
-Voltageを読み出すためのレジスタです。
+BHM VDD_1V0 Bus Voltage Monitor Registerは、VDD_1V0 電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
-BHM Bus Voltage Monitor Registerに格納されるデータは、Current Voltage
-Monitor INA3221-Q1の Bus Voltage Registerからの取得データです。 Bus
-Voltageの実効データは Bit 15:3に格納されます。 Bit 2:0は ALL
-0が格納されます。
+BHM Bus Voltage Monitor Registerに格納されるデータは、Current Voltage Monitor INA3221-Q1の Bus Voltage Registerからの取得データです。
+Bus Voltageの実効データは Bit 15:3に格納されます。 Bit 2:0は ALL 0が格納されます。
 
 .BHM VDD_1V0 Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_1V0BUSVNUPD |VDD_1V0 Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_1V0BUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_1V0BUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_1V0BUSV |VDD_1V0 Bus Voltage Monitor |VDD_1V0
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                          |Description |R/W
+|31    |BHM_1V0BUSVNUPD |VDD_1V0 Bus Voltage Not Updated|センサーデータの更新状態を示すビットです。
+このビットが"1"にセットされている時、BHM_1V0BUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは"0"にクリアされ、BHM_1V0BUSVを読み出したときこのビットは"1"にセットされます。また、
+リセット解除後にセンサーデータが取得されていない状態でも、このビットは"1"を示します。 |RO
+|30:16 |-               |Reserved                       |Reserved |-
+|15:0  |BHM_1V0BUSV     |VDD_1V0 Bus Voltage Monitor    |VDD_1V0電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_1V8 Shunt Voltage Monitor Register (Offset 0x2028)
 
-BHM VDD_1V8 Shunt Voltage Monitor Registerは、VDD_1V8 電源ドメインの
-Shunt Voltageを読み出すためのレジスタです。
+BHM VDD_1V8 Shunt Voltage Monitor Registerは、VDD_1V8 電源ドメインの Shunt Voltageを読み出すためのレジスタです。
 
 .BHM VDD_1V8 Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_1V8SNTVNUPD |VDD_1V8 Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_1V8SNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_1V8SNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_1V8SNTV |VDD_1V8 Shunt Voltage Monitor |VDD_1V8
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                             |Description |R/W
+|31    |BHM_1V8SNTVNUPD |VDD_1V8 Shunt Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_1V8SNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_1V8SNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-               |Reserved                          |Reserved |-
+|15:0  |BHM_1V8SNTV     |VDD_1V8 Shunt Voltage Monitor     |VDD_1V8 電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_1V8 Bus Voltage Monitor Register (Offset 0x202C)
 
-BHM VDD_1V8 Bus Voltage Monitor Registerは、VDD_1V8 電源ドメインの Bus
-Voltageを読み出すためのレジスタです。
+BHM VDD_1V8 Bus Voltage Monitor Registerは、VDD_1V8 電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
 .BHM VDD_1V8 Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_1V8BUSVNUPD |VDD_1V8 Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_1V8BUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_1V8BUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_1V8BUSV |VDD_1V8 Bus Voltage Monitor |VDD_1V8
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                           |Description |R/W
+|31    |BHM_1V8BUSVNUPD |VDD_1V8 Bus Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_1V8BUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_1V8BUSVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-               |Reserved |Reserved              |-
+|15:0  |BHM_1V8BUSV     |VDD_1V8 Bus Voltage Monitor     |VDD_1V8 電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3 Shunt Voltage Monitor Register (Offset 0x2030)
 
-BHM VDD_3V3 Shunt Voltage Monitor Registerは、VDD_3V3 電源ドメインの
-Shunt Voltageを読み出すためのレジスタです。
+BHM VDD_3V3 Shunt Voltage Monitor Registerは、VDD_3V3 電源ドメインの Shunt Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3 Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3SNTVNUPD |VDD_3V3 Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3SNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3SNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3SNTV |VDD_3V3 Shunt Voltage Monitor |VDD_3V3
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                             |Description |R/W
+|31    |BHM_3V3SNTVNUPD |VDD_3V3 Shunt Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_3V3SNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3SNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-               |Reserved                          |Reserved |-
+|15:0  |BHM_3V3SNTV     |VDD_3V3 Shunt Voltage Monitor |VDD_3V3電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3 Bus Voltage Monitor Register (Offset 0x2034)
 
-BHM VDD_3V3 Bus Voltage Monitor Registerは、VDD_3V3 電源ドメインの Bus
-Voltageを読み出すためのレジスタです。
+BHM VDD_3V3 Bus Voltage Monitor Registerは、VDD_3V3 電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3 Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3BUSVNUPD |VDD_3V3 Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3BUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3BUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3BUSV |VDD_3V3 Bus Voltage Monitor |VDD_3V3
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol          |Field                           |Description |R/W
+|31    |BHM_3V3BUSVNUPD |VDD_3V3 Bus Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_3V3BUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3BUSVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-               |Reserved                        |Reserved |-
+|15:0  |BHM_3V3BUSV     |VDD_3V3 Bus Voltage Monitor     |VDD_3V3 電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3SYSA Shunt Voltage Monitor Register (Offset 0x2038)
 
-BHM VDD_3V3SYSA Shunt Voltage Monitor Registerは、VDD_3V3SYSA
-電源ドメインの Shunt Voltageを読み出すためのレジスタです。
+BHM VDD_3V3SYSA Shunt Voltage Monitor Registerは、VDD_3V3SYSA電源ドメインの Shunt Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3SYSA Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3SYSASNTVNUPD |VDD_3V3SYSA Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3SYSASNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3SYSASNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3SYSASNTV |VDD_3V3SYSA Shunt Voltage Monitor
-|VDD_3V3SYSA
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol              |Field                                |Description |R/W
+|31    |BHM_3V3SYSASNTVNUPD |VDD_3V3SYSA Shunt Voltage Not Updated|センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_3V3SYSASNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3SYSASNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-                   |Reserved                             |Reserved |-
+|15:0  |BHM_3V3SYSASNTV     |VDD_3V3SYSA Shunt Voltage Monitor    |VDD_3V3SYSA電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3SYSA Bus Voltage Monitor Register (Offset 0x203C)
 
-BHM VDD_3V3SYSA Bus Voltage Monitor Registerは、VDD_3V3SYSA
-電源ドメインの Bus Voltageを読み出すためのレジスタです。
+BHM VDD_3V3SYSA Bus Voltage Monitor Registerは、VDD_3V3SYSA電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3SYSA Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3SYSABUSVNUPD |VDD_3V3SYSA Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3SYSABUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3SYSABUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3SYSABUSV |VDD_3V3SYSA Bus Voltage Monitor |VDD_3V3SYSA
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol              |Field                               |Description |R/W
+|31    |BHM_3V3SYSABUSVNUPD |VDD_3V3SYSA Bus Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_3V3SYSABUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3SYSABUSV を読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-                   |Reserved                            |Reserved |-
+|15:0  |BHM_3V3SYSABUSV     |VDD_3V3SYSA Bus Voltage Monitor     |VDD_3V3SYSA 電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3SYSB Shunt Voltage Monitor Register (Offset 0x2040)
 
-BHM VDD_3V3SYSB Shunt Voltage Monitor Registerは、VDD_3V3SYSB
-電源ドメインの Shunt Voltageを読み出すためのレジスタです。
+BHM VDD_3V3SYSB Shunt Voltage Monitor Registerは、VDD_3V3SYSB電源ドメインの Shunt Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3SYSB Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3SYSBSNTVNUPD |VDD_3V3SYSB Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3SYSBSNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3SYSBSNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3SYSBSNTV |VDD_3V3SYSB Shunt Voltage Monitor
-|VDD_3V3SYSB
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol              |Field                                 |Description |R/W
+|31    |BHM_3V3SYSBSNTVNUPD |VDD_3V3SYSB Shunt Voltage Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_3V3SYSBSNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3SYSBSNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは"1"を示します。 |RO
+|30:16 |-                   |Reserved                              |Reserved |-
+|15:0  |BHM_3V3SYSBSNTV     |VDD_3V3SYSB Shunt Voltage Monitor     |VDD_3V3SYSB 電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3SYSB Bus Voltage Monitor Register (Offset 0x2044)
 
-BHM VDD_3V3SYSB Bus Voltage Monitor Registerは、VDD_3V3SYSB
-電源ドメインの Bus Voltageを読み出すためのレジスタです。
+BHM VDD_3V3SYSB Bus Voltage Monitor Registerは、VDD_3V3SYSB電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3SYSB Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3SYSBBUSVNUPD |VDD_3V3SYSB Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3SYSBBUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3SYSBBUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3SYSBBUSV |VDD_3V3SYSB Bus Voltage Monitor |VDD_3V3SYSB
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol              |Field                               |Description |R/W
+|31    |BHM_3V3SYSBBUSVNUPD |VDD_3V3SYSB Bus Voltage Not Updated |センサーデータの更新状態を示すビットです。このビットが"1"にセットされている時、BHM_3V3SYSBBUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは"0"にクリアされ、BHM_3V3SYSBBUSVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-                   |Reserved                            |Reserved |-
+|15:0  |BHM_3V3SYSBBUSV     |VDD_3V3SYSB Bus Voltage Monitor     |VDD_3V3SYSB電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3IO Shunt Voltage Monitor Register (Offset 0x2048)
 
-BHM VDD_3V3IO Shunt Voltage Monitor Registerは、VDD_3V3IO
-電源ドメインの Shunt Voltageを読み出すためのレジスタです。
+BHM VDD_3V3IO Shunt Voltage Monitor Registerは、VDD_3V3IO電源ドメインの Shunt Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3IO Shunt Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3IOSNTVNUPD |VDD_3V3IO Shunt Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3IOSNTVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3IOSNTV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3IOSNTV |VDD_3V3IO Shunt Voltage Monitor |VDD_3V3IO
-電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol            |Field                               |Description |R/W
+|31    |BHM_3V3IOSNTVNUPD |VDD_3V3IO Shunt Voltage Not Updated |センサーデータの更新状態を示すビットです。このビットが "1"にセットされている時、BHM_3V3IOSNTVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3IOSNTVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-                 |Reserved                            |Reserved |-
+|15:0  |BHM_3V3IOSNTV     |VDD_3V3IO Shunt Voltage Monitor     |VDD_3V3IO電源ドメインのシャント電圧を読み出すためのフィールドです。シャント電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM VDD_3V3IO Bus Voltage Monitor Register (Offset 0x204C)
 
-BHM VDD_3V3IO Bus Voltage Monitor Registerは、VDD_3V3IO 電源ドメインの
-Bus Voltageを読み出すためのレジスタです。
+BHM VDD_3V3IO Bus Voltage Monitor Registerは、VDD_3V3IO 電源ドメインの Bus Voltageを読み出すためのレジスタです。
 
 .BHM VDD_3V3IO Bus Voltage Monitor Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_3V3IOBUSVNUPD |VDD_3V3IO Bus Voltage Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_3V3IOBUSVフィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_3V3IOBUSV
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_3V3IOBUSV |VDD_3V3IO Bus Voltage Monitor |VDD_3V3IO
-電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは
-Bit 15:3に格納されます。 |RO
+|bit   |Symbol            |Field                             |Description |R/W
+|31    |BHM_3V3IOBUSVNUPD |VDD_3V3IO Bus Voltage Not Updated |センサーデータの更新状態を示すビットです。このビットが "1"にセットされている時、BHM_3V3IOBUSVフィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_3V3IOBUSVを読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-                 |Reserved                          |Reserved |-
+|15:0  |BHM_3V3IOBUSV     |VDD_3V3IO Bus Voltage Monitor     |VDD_3V3IO 電源ドメインのバス電圧を読み出すためのフィールドです。バス電圧の実効データは Bit 15:3に格納されます。 |RO
 |===
 
 ==== BHM Temperature 1-3 Monitor Register (Offset 0x2050 - 0x2058)
 
-BHM Temperature 1-3 Monitor Registerは、Temperature Sensor
-1-3の温度データを読み出すためのレジスタです。
+BHM Temperature 1-3 Monitor Registerは、Temperature Sensor 1-3の温度データを読み出すためのレジスタです。
 
-BHM Temperature 1-3 Monitor Registerに格納されるデータは、温度センサー
-TMP175-Q1の Temperature Registerからの取得データです。
-温度センサーの実効データは Bit 15:4に格納されます。 Bit 3:0は ALL
-0が格納されます。
+BHM Temperature 1-3 Monitor Registerに格納されるデータは、温度センサー TMP175-Q1の Temperature Registerからの取得データです。
+温度センサーの実効データは Bit 15:4に格納されます。 Bit 3:0は ALL 0が格納されます。
 
 .BHM Temperature 1 Monitor Register ビットフィールド (Offset 0x2050)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_TEMP1NUPD |Temperature 1 Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_TEMP1フィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_TEMP1
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_TEMP1 |Temperature 1 Monitor |Temperature Sensor
-1から取得した温度データを読み出すためのフィールドです。温度センサーの実効データは
-Bit 15:4に格納されます。 |RO
+|bit   |Symbol        |Field                     |Description |R/W
+|31    |BHM_TEMP1NUPD |Temperature 1 Not Updated |センサーデータの更新状態を示すビットです。このビットが
+"1"にセットされている時、BHM_TEMP1フィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_TEMP1 を読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。 |RO
+|30:16 |-             |Reserved                  |Reserved |-
+|15:0  |BHM_TEMP1     |Temperature 1 Monitor     |Temperature Sensor 1から取得した温度データを読み出すためのフィールドです。温度センサーの実効データは Bit 15:4に格納されます。 |RO
 |===
 
 .BHM Temperature 2 Monitor Register ビットフィールド (Offset 0x2054)
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31 |BHM_TEMP2NUPD |Temperature 2 Not Updated
-|センサーデータの更新状態を示すビットです。このビットが
-"1"にセットされている時、BHM_TEMP2フィールドが前回の読み出し時から更新されていない事を示します。BHMがセンサーからデータを読み出した時、このビットは
-"0"にクリアされ、BHM_TEMP2
-を読み出したときこのビットは"1"にセットされます。また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは
-"1"を示します。 |RO
-
-|30:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_TEMP2 |Temperature 2 Monitor |Temperature Sensor
-2から取得した温度データを読み出すためのフィールドです。温度センサーの実効データは
-Bit 15:4に格納されます。 |RO
+|bit   |Symbol        |Field                     |Description |R/W
+|31    |BHM_TEMP2NUPD |Temperature 2 Not Updated |センサーデータの更新状態を示すビットです。
+このビットが "1"にセットされている時、BHM_TEMP2フィールドが前回の読み出し時から更新されていない事を示します。
+BHMがセンサーからデータを読み出した時、このビットは "0"にクリアされ、BHM_TEMP2 を読み出したときこのビットは"1"にセットされます。
+また、リセット解除後にセンサーデータが取得されていない状態でも、このビットは "1"を示します。|RO
+|30:16 |-             |Reserved                  |Reserved |-
+|15:0  |BHM_TEMP2     |Temperature 2 Monitor     |Temperature Sensor 2から取得した温度データを読み出すためのフィールドです。温度センサーの実効データは Bit 15:4に格納されます。|RO
 |===
 
 .BHM Temperature 3 Monitor Register ビットフィールド (Offset 0x2058)
@@ -1606,84 +968,65 @@ Bit 15:4に格納されます。 |RO
 
 ==== BHM Software Access Control Register (Offset 0x2060)
 
-BHM Software Access Control Registerは、ソフトウェア指示により
-センサーの任意のレジスタにアクセスするための制御を行うレジスタです。
+BHM Software Access Control Registerは、ソフトウェア指示によりセンサーの任意のレジスタにアクセスするための制御を行うレジスタです。
 
-BHMは Software I2C Access Request (BHM_SWACCREQ)に
-"1"をセットすると、BHM_SWDEVSEL・BHM_SWREGADR・BHM_SWRWSELに設定された情報をもとにアクセスを行います。
+BHMは Software I2C Access Request (BHM_SWACCREQ)に "1"をセットすると、BHM_SWDEVSEL・BHM_SWREGADR・BHM_SWRWSELに設定された情報をもとにアクセスを行います。
 BHM_SWACCREQと他の設定フィールドは、同時にセットすることができます。
 
-BHM_SWRWSELに "0"を設定し、センサーへのライトアクセスを行う場合は、予め
-BHM Software Access Write Data
-Registerにライトデータを書き込んでおく必要があります。
+BHM_SWRWSELに "0"を設定し、センサーへのライトアクセスを行う場合は、予め BHM Software Access Write Data Registerにライトデータを書き込んでおく必要があります。
 
 .BHM Software Access Control Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:25 |- |Reserved |Reserved |-
-
-|24 |BHM_SWACCREQ |Software I2C Access Request
-|Softwareによるセンサーへのアクセスを開始するためのリクエストビットです。このビットに"1"をセットするとセンサーアクセスを開始します。センサーへのアクセスが完了すると、このビットは自動的に
-"0"にクリアされます。 |R/W
-
-|23:19 |- |Reserved |Reserved |-
-
-|18:16 |BHM_SWDEVSEL |Software I2C Access Device Select
-|Softwareによるセンサーへのアクセスを行う時のセンサーデバイスを選択するためのフィールドです。0x0:
-Current Voltage Monitor 1 0x1: Current Voltage Monitor 2 0x2:
-Temperature Sensor 1 0x3: Temperature Sensor 2 0x4: Temperature Sensor 3
+|bit   |Symbol       |Field                       |Description |R/W
+|31:25 |-            |Reserved                    |Reserved    |-
+|24    |BHM_SWACCREQ |Software I2C Access Request |Softwareによるセンサーへのアクセスを開始するためのリクエストビットです。
+このビットに"1"をセットするとセンサーアクセスを開始します。
+センサーへのアクセスが完了すると、このビットは自動的に "0"にクリアされます。 |R/W
+|23:19 |-            |Reserved                              |Reserved |-
+|18:16 |BHM_SWDEVSEL |Software I2C Access Device Select     |Softwareによるセンサーへのアクセスを行う時のセンサーデバイスを選択するためのフィールドです。 +
+0x0: Current Voltage Monitor 1 +
+0x1: Current Voltage Monitor 2 +
+0x2: Temperature Sensor 1 +
+0x3: Temperature Sensor 2 +
+0x4: Temperature Sensor 3 +
 0x5-0x7: 設定禁止 |R/W
-
-|15:8 |BHM_SWREGADR |Software I2C Access Register Address
-|Softwareによるセンサーへのアクセスを行う時のセンサーのレジスタのアドレスを設定するためのフィールドです。
-|R/W
-
-|7:1 |- |Reserved |Reserved |-
-
-|0 |BHM_SWRWSEL |Software I2C Access Read/Write Select
-|Softwareによるセンサーへのアクセスを行う時のアクセス方向
-(リード/ライト)を設定するためのビットです。 0: Write Access 1: Read
-Access |R/W
+|15:8  |BHM_SWREGADR |Software I2C Access Register Address  |Softwareによるセンサーへのアクセスを行う時のセンサーのレジスタのアドレスを設定するためのフィールドです。|R/W
+|7:1   |-            |Reserved                              |Reserved |-
+|0     |BHM_SWRWSEL  |Software I2C Access Read/Write Select |Softwareによるセンサーへのアクセスを行う時のアクセス方向 (リード/ライト)を設定するためのビットです。 +
+0: Write Access +
+1: Read Access |R/W
 |===
 
 ==== BHM Software Access Write Data Register (Offset 0x2064)
 
-BHM Software Access Write Data Registerは、ソフトウェア指示による
-I2Cアクセスにおいて、センサーに送信するデータを書き込むためのレジスタです。
+BHM Software Access Write Data Registerは、ソフトウェア指示による I2Cアクセスにおいて、センサーに送信するデータを書き込むためのレジスタです。
 
 .BHM Software Access Write Data Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_SWWRDATA |Software I2C Access Write Data
-|センサーに送信するデータを設定するフィールドです。 |R/W
+|bit   |Symbol       |Field                          |Description                                        |R/W
+|31:16 |-            |Reserved                       |Reserved                                           |-
+|15:0  |BHM_SWWRDATA |Software I2C Access Write Data |センサーに送信するデータを設定するフィールドです。 |R/W
 |===
 
 ==== BHM Software Access Read Data Register (Offset 0x2068)
 
-BHM Software Access Read Data Registerは、ソフトウェア指示による
-I2Cアクセスによってセンサーから受信したデータを読み出すためのレジスタです。
+BHM Software Access Read Data Registerは、ソフトウェア指示による I2Cアクセスによってセンサーから受信したデータを読み出すためのレジスタです。
 
 .BHM Software Access Write Data Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_SWRDDATA |Software I2C Access Read Data
-|センサーから受信したデータを読み出すためのフィールドです。 |RO
+|bit   |Symbol       |Field                         |Description                                                |R/W
+|31:16 |-            |Reserved                      |Reserved                                                   |-
+|15:0  |BHM_SWRDDATA |Software I2C Access Read Data |センサーから受信したデータを読み出すためのフィールドです。 |RO
 |===
 
 ==== BHM Prescaler Register (Offset 0x2080)
 
-BHM Prescale Registerは、BHMがセンサーと行う I2Cの
-通信タイミングを設定するためのレジスタです。
+BHM Prescale Registerは、BHMがセンサーと行う I2Cの通信タイミングを設定するためのレジスタです。
 
-OBC Module上のセンサーとの通信は I2Cの Standard mode (100
-Kbps)で行います。
+OBC Module上のセンサーとの通信は I2Cの Standard mode (100 Kbps)で行います。
 このレジスタには、以下の計算値で設定される値を設定してください。
 
 [stem]
@@ -1694,15 +1037,12 @@ BHM\_CLKPSC = \frac{System\ Clock\ frequency [MHz]}{0.1} - 1
 .BHM Prescale Setting Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:16 |- |Reserved |Reserved |-
-
-|15:0 |BHM_CLKPSC |I2C Prescale From System Clock |システムクロックで
-I2Cの 1周期を生成するカウント数を設定します。 |R/W
+|bit   |Symbol     |Field                          |Description                                                      |R/W
+|31:16 |-          |Reserved                       |Reserved                                                         |-
+|15:0  |BHM_CLKPSC |I2C Prescale From System Clock |システムクロックで I2Cの 1周期を生成するカウント数を設定します。 |R/W
 |===
 
-BHM_CLKPDCの設定による
-I2C通信の各タイミングは、以下の式で計算できます。
+BHM_CLKPDCの設定による I2C通信の各タイミングは、以下の式で計算できます。
 
 [stem]
 ++++
@@ -1751,112 +1091,64 @@ kbpsに設定する場合の設定値と、I2Cのタイミングを以下に示�
 Registerの設定値とI2Cタイミング (システムクロックのサイクル数)
 [cols=",,",options="header",]
 |===
-|Parameter |System Clock=48MHz[default] |System Clock=24MHz
-|SYSMON_BHMCLKPSC[15:0] 設定値 |0x01DF [Divide by 480] |0x00EF [Divide
-by 240]
-
-|START Hold Timing (tHDSTA) |240 Cycle [5.00us] |120 Cycle [5.00us]
-
-|STOP Setup Timing (tSUSTO) |240 Cycle [5.00us] |120 Cycle [5.00us]
-
-|Repeated START Setup Timing (tSUSTA) |240 Cycle [5.00us] |120 Cycle
-[5.00us]
-
-|Clock High Timing (tHIGH) |235 Cycle [4.90us] |115 Cycle [4.79us]
-
-|Data Hold Timing (tHDDAT) |5 Cycle [0.10us] |5 Cycle [0.21us]
-
-|Data Setup Timing (tSUDAT) |240 Cycle [5.00us] |120 Cycle [5.00us]
-
-|Clock Low Timing (tLOW) |245 Cycle [5.10us] |125 Cycle [5.21us]
-
-|Bus Free Timing (tBUF) |245 Cycle [5.10us] |125 Cycle [5.21us]
+|Parameter                            |System Clock=48MHz[default] |System Clock=24MHz
+|SYSMON_BHMCLKPSC[15:0] 設定値        |0x01DF [Divide by 480]      |0x00EF [Divide by 240]
+|START Hold Timing (tHDSTA)           |240 Cycle [5.00us]          |120 Cycle [5.00us]
+|STOP Setup Timing (tSUSTO)           |240 Cycle [5.00us]          |120 Cycle [5.00us]
+|Repeated START Setup Timing (tSUSTA) |240 Cycle [5.00us]          |120 Cycle [5.00us]
+|Clock High Timing (tHIGH)            |235 Cycle [4.90us]          |115 Cycle [4.79us]
+|Data Hold Timing (tHDDAT)            |5 Cycle [0.10us]            |5 Cycle [0.21us]
+|Data Setup Timing (tSUDAT)           |240 Cycle [5.00us]          |120 Cycle [5.00us]
+|Clock Low Timing (tLOW)              |245 Cycle [5.10us]          |125 Cycle [5.21us]
+|Bus Free Timing (tBUF)               |245 Cycle [5.10us]          |125 Cycle [5.21us]
 |===
 
 ==== BHM Retry Count Register (Offset 0x2084)
 
-BHM Retry Count
-Registerは、BHMが行うセンサーへのアクセスにおける、リトライ回数の上限を設定するためのレジスタです。
+BHM Retry Count Registerは、BHMが行うセンサーへのアクセスにおける、リトライ回数の上限を設定するためのレジスタです。
 
-BHMは
-I2Cバスの通信においてセンサーからアクノリッジが送信されてこない場合にバスエラーと認識します。
+BHMは I2Cバスの通信においてセンサーからアクノリッジが送信されてこない場合にバスエラーと認識します。
 BHMはバスエラーが起こった場合、BHM_I2CACCCNTに設定された回数のリトライアクセスを行います。
 
-I2Cアクセスが頻発する事により、BHM_I2CACCCNTに設定されたリトライを行ってもエラーが改善しなかった場合、BHMは
-I2Cアクセスを停止します。 このとき、BHM Access Control
-Registerの対象のセンサーの Enableビットを Disableに設定するとともに、BHM
-Interrupt Status Registerの対象のセンサーの I2C Access
-Errorビットをセットし、割り込みを発生します。
+I2Cアクセスが頻発する事により、BHM_I2CACCCNTに設定されたリトライを行ってもエラーが改善しなかった場合、BHMは I2Cアクセスを停止します。
+このとき、BHM Access Control Registerの対象のセンサーの Enableビットを Disableに設定するとともに、BHM Interrupt Status Registerの対象のセンサーの I2C Access Errorビットをセットし、割り込みを発生します。
 
 .BHM Retry Count Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:8 |- |Reserved |Reserved |-
-
-|7:0 |BHM_I2CACCCNT |I2C Access Count
-|I2Cアクセスにおけるリトライ回数を設定するフィールドです。 |R/W
+|bit  |Symbol        |Field             |Description                                               |R/W
+|31:8 |-             |Reserved          |Reserved                                                  |-
+|7:0  |BHM_I2CACCCNT |I2C Access Count  |I2Cアクセスにおけるリトライ回数を設定するフィールドです。 |R/W
 |===
 
 ==== BHM Access Status Register (Offset 0x20C0)
 
-BHM Access Status Registerは、BHM機能が持つ
-I2Cバスの状態を示すレジスタです。
+BHM Access Status Registerは、BHM機能が持つ I2Cバスの状態を示すレジスタです。
 
-このレジスタの全てのビットが "0"を示す時、I2Cバスは
-Idle状態であることを示します。
+このレジスタの全てのビットが "0"を示す時、I2Cバスは Idle状態であることを示します。
 
 .BHM Access Status Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:6 |- |Reserved |Reserved |-
-
-|5 |BHM_SWBUSY |Software Access Busy
-|ソフトウェアからの指示により、BHMが
-いずれからのセンサーに対して行うアクセスの状態を示すビットです。 |RO
-
-|4 |BHM_TEMP3BUSY |Temperature Sensor3 Access Busy |BHMが Temperature
-Sensor
-3に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは
-"1"を示します。 |RO
-
-|3 |BHM_TEMP2BUSY |Temperature Sensor2 Access Busy |BHMが Temperature
-Sensor
-2に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは
-"1"を示します。 |RO
-
-|2 |BHM_TEMP1BUSY |Temperature Sensor1 Access Busy |BHMが Temperature
-Sensor
-1に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは
-"1"を示します。 |RO
-
-|1 |BHM_CVM2BUSY |Current Voltage Monitor2 Access Busy |BHMが Current
-Voltage Monitor
-2に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータの読み出し時に、このビットは
-"1"を示します。 |RO
-
-|0 |BHM_CVM1BUSY |Current Voltage Monitor1 Access Busy |BHMが Current
-Voltage Monitor
-1に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータの読み出し時に、このビットは
-"1"を示します。 |RO
+|bit  |Symbol        |Field                                |Description                                                                                                                                          |R/W
+|31:6 |-             |Reserved                             |Reserved                                                                                                                                             |-
+|5    |BHM_SWBUSY    |Software Access Busy                 |ソフトウェアからの指示により、BHMが いずれからのセンサーに対して行うアクセスの状態を示すビットです。                                                 |RO
+|4    |BHM_TEMP3BUSY |Temperature Sensor3 Access Busy      |BHMが Temperature Sensor 3に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは "1"を示します。       |RO
+|3    |BHM_TEMP2BUSY |Temperature Sensor2 Access Busy      |BHMが Temperature Sensor 2に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは "1"を示します。       |RO
+|2    |BHM_TEMP1BUSY |Temperature Sensor1 Access Busy      |BHMが Temperature Sensor 1に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータ読み出し時に、このビットは "1"を示します。       |RO
+|1    |BHM_CVM2BUSY  |Current Voltage Monitor2 Access Busy |BHMが Current Voltage Monitor 2に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータの読み出し時に、このビットは "1"を示します。|RO
+|0    |BHM_CVM1BUSY  |Current Voltage Monitor1 Access Busy |BHMが Current Voltage Monitor 1に対して行う自動アクセスの状態を示すビットです。センサーの初期化時とデータの読み出し時に、このビットは"1"を示します。 |RO
 |===
 
 ==== System Monitor IP Version Register (Offset: 0xF000)
 
-System Monitor IP Version Registerは、System Monitorの
-IPコアバージョンを示すレジスタです。
+System Monitor IP Version Registerは、System Monitorの IPコアバージョンを示すレジスタです。
 
 .System Monitor IP Version Register ビットフィールド
 [cols="1,3,3,12,1",options="header",]
 |===
-|bit |Symbol |Field |Description |R/W
-|31:24 |SYSMON_MAJVER |System Monitor IP Major Version |System
-MonitorコアのMajor Versionを示します。 |RO
-
-|23:16 |SYSMON_MINVER |System Monitor IP Minor Version |System
-MonitorコアのMinor Versionを示します。 |RO
-
-|15:0 |SYSMON_PATVER |System Monitor IP Patch Version |System
-MonitorコアのPatch Versionを示します。 |RO
+|bit   |Symbol        |Field                            |Description                                   |R/W
+|31:24 |SYSMON_MAJVER |System Monitor IP Major Version  |System MonitorコアのMajor Versionを示します。 |RO
+|23:16 |SYSMON_MINVER |System Monitor IP Minor Version  |System MonitorコアのMinor Versionを示します。 |RO
+|15:0  |SYSMON_PATVER |System Monitor IP Patch Version  |System MonitorコアのPatch Versionを示します。 |RO
 |===

--- a/modules/ROOT/pages/system_register.adoc
+++ b/modules/ROOT/pages/system_register.adoc
@@ -8,7 +8,7 @@ FPGAのシステム制御を司るレジスタで構成されるモジュール�
 System Registerは、Base Address 0x4F00_0000に配置されています。
 
 .System Registerメモリマップ
-[cols=",,,",options="header",]
+[cols="4,4,10,2",options="header",]
 |===
 |Offset |Symbol           |Register                            |Initial
 |0x0000 |SYSREG_CODEMSEL  |Code Memory Select Register         |0x00000001


### PR DESCRIPTION
Refactored the documentation to fix unintended line breaks that were introduced during the migration to .adoc format.

Additionally, updated the formatting to take advantage of .adoc's support for table width control and line breaks within table cells, improving overall layout and readability.